### PR TITLE
New benchmark workflow

### DIFF
--- a/.github/workflows/benchmarks-run.yml
+++ b/.github/workflows/benchmarks-run.yml
@@ -1,0 +1,96 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Benchmarks Run
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch"
+        required: true
+      pallets:
+        description: "Specific Pallets? (Ex: 'msa,messages')"
+        required: true
+        default: all
+
+jobs:
+  run-benchmarks:
+    if: github.repository == 'frequency-chain/frequency'
+    name: Run Benchmarks
+    runs-on: [self-hosted, Linux, X64, benchmark]
+    permissions:
+      contents: write
+      statuses: write
+      pull-requests: write
+    steps:
+      - name: Print Info
+        run: |
+          echo "Running benchmarks..."
+          echo "Pallets: ${{github.event.inputs.pallets}}"
+      - name: Check Out Repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{github.event.inputs.branch}}
+      - name: Get Current Job Log URL
+        id: jobs
+        uses: Tiryoh/gha-jobid-action@c1d1cf7334b70c29374ae382b91053674c8049a2
+        with:
+          github_token: ${{ github.token }}
+          job_name: "Run Benchmarks"
+      - name: Set PR Commit Status to Pending
+        uses: ouzi-dev/commit-status-updater@219d3f932547cad092e384c7a36bf4d963739c35
+        with:
+          name: "GithubActions - Run Benchmarks"
+          status: "pending"
+          addHoldComment: "true"
+          pendingComment: >-
+            :hourglass_flowing_sand: [Running benchmarks](${{steps.jobs.outputs.html_url}})
+            and calculating weights. DO NOT MERGE! A new commit will be added upon completion...
+          failComment: "ERROR: Failed to set commit to pending status!"
+      - name: Install Required Packages
+        run: |
+          sudo apt-get update
+          sudo apt install -y protobuf-compiler libclang-dev clang cmake
+      - name: Install Rust Toolchain
+        # Match installation steps to CI base docker image
+        run: |
+          curl https://sh.rustup.rs -sSf | HOME=`pwd` bash -s -- -y
+          echo "PATH=`pwd`/.cargo/bin:$PATH" >> $GITHUB_ENV
+      - name: Update Weights
+        run: |
+          rustup show
+          pallets_str="${{github.event.inputs.pallets}}"
+          echo "Pallets: $pallets_str"
+          if [ -z "${pallets_str}" -o $pallets_str = 'all' ]; then
+            echo "Running benchmarks for all pallets..."
+            make benchmarks
+          else
+            IFS=',' read -r -a pallets <<< "$pallets_str"
+              echo "Running benchmarks for pallets: ${pallets[*]}..."
+              make benchmarks-multi PALLETS="${pallets[*]}"
+              echo "Finished benchmarks for pallets: ${pallets[*]}."
+          fi
+      - name: Print Updated Weights
+        run: |
+          git status
+          git diff
+
+      - name: Commit Updated Weights
+        id: commit-updated-weights
+        uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d
+        with:
+          commit_message: "Update weights for #${{github.event.inputs.branch}}"
+          file_pattern: "pallets/**/*.rs runtime/common/src/weights/*"
+
+      - name: Set Commit Status to Success
+        uses: ouzi-dev/commit-status-updater@219d3f932547cad092e384c7a36bf4d963739c35
+        with:
+          name: "GithubActions - Run Benchmarks"
+          status: "success"
+          addHoldComment: "true"
+          successComment: >-
+            :white_check_mark: [Finished running benchmarks](${{steps.jobs.outputs.html_url}}).
+            Updated weights have been committed to this branch in
+            commit ${{steps.commit-updated-weights.outputs.commit_hash}}.
+          failComment: "ERROR: Failed to set commit to success status!"


### PR DESCRIPTION
# Goal
The goal of this PR is to create a new flow for benchmarks so that they are easier to run and do not require a separate github token.

To test this must be in main as `workflow_dispatch` doesn't work without being in `main`, but here is a run that was triggered using defaults with a few other tweaks: https://github.com/frequency-chain/frequency/actions/runs/9174859575

# Discussion
- The PR #1971 will remove the old system from the `.github/workflows/verify-pr-commit.yml` file so that only this one is used
- Once PR #1971 is merged, I will also update the wiki with the new instructions