### PR TITLE
Feat/rename staking to provider boost #1976

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,11 +84,11 @@ specs-rococo-local:
 
 .PHONY: format
 format:
-	cargo +nightly-2024-03-01 fmt
+	cargo fmt
 
 .PHONY: lint, lint-audit
 lint:
-	cargo +nightly-2024-03-01 fmt --check
+	cargo fmt --check
 	SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy --features runtime-benchmarks,frequency-lint-check -- -D warnings
 	RUSTC_BOOTSTRAP=1 RUSTDOCFLAGS="--enable-index-page --check -Zunstable-options" cargo doc --no-deps --features frequency
 

--- a/pallets/capacity/src/benchmarking.rs
+++ b/pallets/capacity/src/benchmarking.rs
@@ -137,7 +137,7 @@ benchmarks! {
 
 	start_new_reward_era_if_needed {
 		let current_block: BlockNumberFor<T> = 1_209_600u32.into();
-		let history_limit: u32 = <T as Config>::ProviderBoostRewardsPastErasMax::get();
+		let history_limit: u32 = <T as Config>::ProviderBoostHistoryLimit::get();
 		let total_reward_pool: BalanceOf<T> = <T as Config>::RewardPoolEachEra::get();
 		let unclaimed_balance: BalanceOf<T> = 5_000u32.into();
 		let total_staked_token: BalanceOf<T> = 5_000u32.into();

--- a/pallets/capacity/src/benchmarking.rs
+++ b/pallets/capacity/src/benchmarking.rs
@@ -52,7 +52,7 @@ pub fn set_era_and_reward_pool_at_block<T: Config>(
 		total_reward_pool,
 		unclaimed_balance: total_reward_pool,
 	};
-	StakingRewardPool::<T>::insert(era_index, pool_info);
+	ProviderBoostRewardPool::<T>::insert(era_index, pool_info);
 }
 
 // caller stakes the given amount to the given target
@@ -137,7 +137,7 @@ benchmarks! {
 
 	start_new_reward_era_if_needed {
 		let current_block: BlockNumberFor<T> = 1_209_600u32.into();
-		let history_limit: u32 = <T as Config>::StakingRewardsPastErasMax::get();
+		let history_limit: u32 = <T as Config>::ProviderBoostRewardsPastErasMax::get();
 		let total_reward_pool: BalanceOf<T> = <T as Config>::RewardPoolEachEra::get();
 		let unclaimed_balance: BalanceOf<T> = 5_000u32.into();
 		let total_staked_token: BalanceOf<T> = 5_000u32.into();
@@ -148,7 +148,7 @@ benchmarks! {
 
 		for i in 0..history_limit {
 			let era: T::RewardEra = i.into();
-			StakingRewardPool::<T>::insert(era, RewardPoolInfo { total_staked_token, total_reward_pool, unclaimed_balance});
+			ProviderBoostRewardPool::<T>::insert(era, RewardPoolInfo { total_staked_token, total_reward_pool, unclaimed_balance});
 		}
 	}: {
 		Capacity::<T>::start_new_reward_era_if_needed(current_block);

--- a/pallets/capacity/src/lib.rs
+++ b/pallets/capacity/src/lib.rs
@@ -175,7 +175,7 @@ pub mod pallet {
 		type CapacityPerToken: Get<Perbill>;
 
 		/// A period of `EraLength` blocks in which a Staking Pool applies and
-		/// when Staking Rewards may be earned.
+		/// when Provider Boost Rewards may be earned.
 		type RewardEra: Parameter
 			+ Member
 			+ MaybeSerializeDeserialize
@@ -198,10 +198,10 @@ pub mod pallet {
 		/// Note that you can claim rewards even if you no longer are boosting, because you
 		/// may claim rewards for past eras up to the history limit.
 		#[pallet::constant]
-		type StakingRewardsPastErasMax: Get<u32>;
+		type ProviderBoostRewardsPastErasMax: Get<u32>;
 
-		/// The StakingRewardsProvider used by this pallet in a given runtime
-		type RewardsProvider: StakingRewardsProvider<Self>;
+		/// The BoostingRewardsProvider used by this pallet in a given runtime
+		type RewardsProvider: BoostingRewardsProvider<Self>;
 
 		/// A staker may not retarget more than MaxRetargetsPerRewardEra
 		#[pallet::constant]
@@ -275,7 +275,7 @@ pub mod pallet {
 	pub type UnstakeUnlocks<T: Config> =
 		StorageMap<_, Twox64Concat, T::AccountId, UnlockChunkList<T>>;
 
-	/// Information about the current staking reward era. Checked every block.
+	/// Information about the current reward era. Checked every block.
 	#[pallet::storage]
 	#[pallet::whitelist_storage]
 	#[pallet::getter(fn get_current_era)]
@@ -285,7 +285,7 @@ pub mod pallet {
 	/// Reward Pool history
 	#[pallet::storage]
 	#[pallet::getter(fn get_reward_pool_for_era)]
-	pub type StakingRewardPool<T: Config> =
+	pub type ProviderBoostRewardPool<T: Config> =
 		CountedStorageMap<_, Twox64Concat, T::RewardEra, RewardPoolInfo<BalanceOf<T>>>;
 
 	#[pallet::storage]
@@ -787,7 +787,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn set_reward_pool(era: <T>::RewardEra, new_reward_pool: &RewardPoolInfo<BalanceOf<T>>) {
-		StakingRewardPool::<T>::set(era, Some(new_reward_pool.clone()));
+		ProviderBoostRewardPool::<T>::set(era, Some(new_reward_pool.clone()));
 	}
 
 	/// Decrease a staking account's active token and reap if it goes below the minimum.
@@ -969,19 +969,19 @@ impl<T: Config> Pallet<T> {
 				era_index: current_era_info.era_index.saturating_add(One::one()),
 				started_at: current_block,
 			};
+			CurrentEraInfo::<T>::set(new_era_info); // 1w
 
 			let current_reward_pool =
 				Self::get_reward_pool_for_era(current_era_info.era_index).unwrap_or_default(); // 1r
 
-			let past_eras_max = T::StakingRewardsPastErasMax::get();
-			let entries: u32 = StakingRewardPool::<T>::count(); // 1r
+			let past_eras_max = T::ProviderBoostRewardsPastErasMax::get();
+			let entries: u32 = ProviderBoostRewardPool::<T>::count(); // 1r
 
 			if past_eras_max.eq(&entries) {
 				let earliest_era =
 					current_era_info.era_index.saturating_sub(past_eras_max.into()).add(One::one());
-				StakingRewardPool::<T>::remove(earliest_era); // 1w
+				ProviderBoostRewardPool::<T>::remove(earliest_era); // 1w
 			}
-			CurrentEraInfo::<T>::set(new_era_info); // 1w
 
 			let total_reward_pool =
 				T::RewardsProvider::reward_pool_size(current_reward_pool.total_staked_token);
@@ -990,7 +990,7 @@ impl<T: Config> Pallet<T> {
 				total_reward_pool,
 				unclaimed_balance: total_reward_pool,
 			};
-			StakingRewardPool::<T>::insert(new_era_info.era_index, new_reward_pool); // 1w
+			ProviderBoostRewardPool::<T>::insert(new_era_info.era_index, new_reward_pool); // 1w
 			T::WeightInfo::start_new_reward_era_if_needed()
 		} else {
 			T::DbWeight::get().reads(1)
@@ -1085,10 +1085,11 @@ impl<T: Config> Pallet<T> {
 	#[allow(unused)]
 	pub(crate) fn list_unclaimed_rewards(
 		account: &T::AccountId,
-	) -> Result<BoundedVec<UnclaimedRewardInfo<T>, T::StakingRewardsPastErasMax>, DispatchError> {
+	) -> Result<BoundedVec<UnclaimedRewardInfo<T>, T::ProviderBoostRewardsPastErasMax>, DispatchError>
+	{
 		let mut unclaimed_rewards: BoundedVec<
 			UnclaimedRewardInfo<T>,
-			T::StakingRewardsPastErasMax,
+			T::ProviderBoostRewardsPastErasMax,
 		> = BoundedVec::new();
 
 		if !Self::has_unclaimed_rewards(account) {
@@ -1101,7 +1102,7 @@ impl<T: Config> Pallet<T> {
 
 		let era_info = Self::get_current_era(); // cached read, ditto
 
-		let max_history: u32 = T::StakingRewardsPastErasMax::get() - 1; // 1r
+		let max_history: u32 = T::ProviderBoostRewardsPastErasMax::get() - 1; // 1r
 		let era_length: u32 = T::EraLength::get(); // 1r
 		let mut reward_era = era_info.era_index.saturating_sub((max_history).into());
 		let end_era = era_info.era_index.saturating_sub(One::one());
@@ -1145,7 +1146,7 @@ impl<T: Config> Pallet<T> {
 				previous_amount = staked_amount;
 			}
 			reward_era = reward_era.saturating_add(One::one());
-		} // 1r * up to StakingRewardsPastErasMax-1, if they staked every RewardEra.
+		} // 1r * up to ProviderBoostRewardsPastErasMax-1, if they staked every RewardEra.
 		Ok(unclaimed_rewards)
 	}
 }
@@ -1227,7 +1228,7 @@ impl<T: Config> Replenishable for Pallet<T> {
 	}
 }
 
-impl<T: Config> StakingRewardsProvider<T> for Pallet<T> {
+impl<T: Config> BoostingRewardsProvider<T> for Pallet<T> {
 	type AccountId = T::AccountId;
 	type RewardEra = T::RewardEra;
 	type Hash = T::Hash;
@@ -1247,7 +1248,7 @@ impl<T: Config> StakingRewardsProvider<T> for Pallet<T> {
 	) -> Result<Self::Balance, DispatchError> {
 		let era_range = from_era.saturating_sub(to_era);
 		ensure!(
-			era_range.le(&T::StakingRewardsPastErasMax::get().into()),
+			era_range.le(&T::ProviderBoostRewardsPastErasMax::get().into()),
 			Error::<T>::EraOutOfRange
 		);
 		ensure!(from_era.le(&to_era), Error::<T>::EraOutOfRange);
@@ -1262,7 +1263,7 @@ impl<T: Config> StakingRewardsProvider<T> for Pallet<T> {
 		Ok(per_era.saturating_mul(num_eras.into()))
 	}
 
-	/// Calculate the staking reward for a single era.  We don't care about the era number,
+	/// Calculate the reward for a single era.  We don't care about the era number,
 	/// just the values.
 	fn era_staking_reward(
 		era_amount_staked: Self::Balance,
@@ -1280,7 +1281,7 @@ impl<T: Config> StakingRewardsProvider<T> for Pallet<T> {
 	fn validate_staking_reward_claim(
 		_account_id: Self::AccountId,
 		_proof: Self::Hash,
-		_payload: StakingRewardClaim<T>,
+		_payload: ProviderBoostRewardClaim<T>,
 	) -> bool {
 		true
 	}

--- a/pallets/capacity/src/migration/provider_boost_init.rs
+++ b/pallets/capacity/src/migration/provider_boost_init.rs
@@ -1,4 +1,4 @@
-use crate::{Config, CurrentEraInfo, RewardEraInfo, RewardPoolInfo, StakingRewardPool};
+use crate::{Config, CurrentEraInfo, ProviderBoostRewardPool, RewardEraInfo, RewardPoolInfo};
 use frame_support::{
 	pallet_prelude::Weight,
 	traits::{Get, OnRuntimeUpgrade},
@@ -18,7 +18,7 @@ impl<T: Config> OnRuntimeUpgrade for ProviderBoostInit<T> {
 			let current_block = frame_system::Pallet::<T>::block_number(); // 1r
 			let era_index: T::RewardEra = 0u32.into();
 			CurrentEraInfo::<T>::set(RewardEraInfo { era_index, started_at: current_block }); // 1w
-			StakingRewardPool::<T>::insert(era_index, RewardPoolInfo::default()); // 1w
+			ProviderBoostRewardPool::<T>::insert(era_index, RewardPoolInfo::default()); // 1w
 			T::DbWeight::get().reads_writes(2, 2)
 		} else {
 			T::DbWeight::get().reads(1)
@@ -32,10 +32,10 @@ impl<T: Config> OnRuntimeUpgrade for ProviderBoostInit<T> {
 		} else {
 			log::info!("CurrentEraInfo not found. Initialization should proceed.");
 		}
-		if StakingRewardPool::<T>::iter().count() == 0usize {
-			log::info!("StakingRewardPool will be updated with Era 0");
+		if ProviderBoostRewardPool::<T>::iter().count() == 0usize {
+			log::info!("ProviderBoostRewardPool will be updated with Era 0");
 		} else {
-			log::info!("StakingRewardPool has already been initialized.")
+			log::info!("ProviderBoostRewardPool has already been initialized.")
 		}
 		Ok(Vec::default())
 	}
@@ -47,7 +47,7 @@ impl<T: Config> OnRuntimeUpgrade for ProviderBoostInit<T> {
 		let info = CurrentEraInfo::<T>::get();
 		assert_eq!(info.started_at, current_block);
 		log::info!("CurrentEraInfo.started_at is set to {:?}.", info.started_at);
-		assert_eq!(StakingRewardPool::<T>::iter().count(), 1);
+		assert_eq!(ProviderBoostRewardPool::<T>::iter().count(), 1);
 		Ok(())
 	}
 }

--- a/pallets/capacity/src/tests/eras_tests.rs
+++ b/pallets/capacity/src/tests/eras_tests.rs
@@ -24,7 +24,7 @@ fn start_new_era_if_needed_updates_era_info() {
 				RewardEraInfo { era_index: expected_era, started_at: block_decade }
 			);
 
-			let past_eras_max: u32 = <Test as Config>::ProviderBoostRewardsPastErasMax::get();
+			let past_eras_max: u32 = <Test as Config>::ProviderBoostHistoryLimit::get();
 			assert!(ProviderBoostRewardPool::<Test>::count().le(&past_eras_max));
 			system_run_to_block(block_decade + 9);
 		}

--- a/pallets/capacity/src/tests/eras_tests.rs
+++ b/pallets/capacity/src/tests/eras_tests.rs
@@ -1,7 +1,7 @@
 use super::mock::*;
 use crate::{
 	tests::testing_utils::{run_to_block, setup_provider, system_run_to_block},
-	Config, CurrentEraInfo, RewardEraInfo, RewardPoolInfo, StakingRewardPool,
+	Config, CurrentEraInfo, ProviderBoostRewardPool, RewardEraInfo, RewardPoolInfo,
 	StakingType::*,
 };
 use common_primitives::msa::MessageSourceId;
@@ -24,8 +24,8 @@ fn start_new_era_if_needed_updates_era_info() {
 				RewardEraInfo { era_index: expected_era, started_at: block_decade }
 			);
 
-			let past_eras_max: u32 = <Test as Config>::StakingRewardsPastErasMax::get();
-			assert!(StakingRewardPool::<Test>::count().le(&past_eras_max));
+			let past_eras_max: u32 = <Test as Config>::ProviderBoostRewardsPastErasMax::get();
+			assert!(ProviderBoostRewardPool::<Test>::count().le(&past_eras_max));
 			system_run_to_block(block_decade + 9);
 		}
 	})
@@ -48,9 +48,9 @@ fn start_new_era_if_needed_updates_reward_pool() {
 			let final_block = (i * 10) + 1;
 			system_run_to_block(final_block - 1);
 			run_to_block(final_block);
-			assert_eq!(StakingRewardPool::<Test>::count(), era);
+			assert_eq!(ProviderBoostRewardPool::<Test>::count(), era);
 			assert_eq!(
-				StakingRewardPool::<Test>::get(era).unwrap(),
+				ProviderBoostRewardPool::<Test>::get(era).unwrap(),
 				RewardPoolInfo {
 					total_staked_token: (stake_amount * i as u64),
 					total_reward_pool: 10_000,

--- a/pallets/capacity/src/tests/mock.rs
+++ b/pallets/capacity/src/tests/mock.rs
@@ -1,8 +1,8 @@
 use crate as pallet_capacity;
 
 use crate::{
-	tests::testing_utils::set_era_and_reward_pool, BalanceOf, BoostingRewardsProvider,
-	ProviderBoostRewardClaim,
+	tests::testing_utils::set_era_and_reward_pool, BalanceOf, ProviderBoostRewardClaim,
+	ProviderBoostRewardsProvider,
 };
 use common_primitives::{
 	node::{AccountId, Hash, ProposalProvider},
@@ -138,7 +138,7 @@ pub struct TestRewardsProvider {}
 
 type TestRewardEra = u32;
 
-impl BoostingRewardsProvider<Test> for TestRewardsProvider {
+impl ProviderBoostRewardsProvider<Test> for TestRewardsProvider {
 	type AccountId = u64;
 	type RewardEra = TestRewardEra;
 	type Hash = Hash; // use what's in common_primitives::node
@@ -208,7 +208,7 @@ impl pallet_capacity::Config for Test {
 	type CapacityPerToken = TestCapacityPerToken;
 	type RewardEra = TestRewardEra;
 	type EraLength = ConstU32<10>;
-	type ProviderBoostRewardsPastErasMax = ConstU32<6>; // 5 for claiming rewards, 1 for current reward era
+	type ProviderBoostHistoryLimit = ConstU32<6>; // 5 for claiming rewards, 1 for current reward era
 	type RewardsProvider = Capacity;
 	type MaxRetargetsPerRewardEra = ConstU32<5>;
 	type RewardPoolEachEra = ConstU64<10_000>;

--- a/pallets/capacity/src/tests/mock.rs
+++ b/pallets/capacity/src/tests/mock.rs
@@ -1,8 +1,8 @@
 use crate as pallet_capacity;
 
 use crate::{
-	tests::testing_utils::set_era_and_reward_pool, BalanceOf, StakingRewardClaim,
-	StakingRewardsProvider,
+	tests::testing_utils::set_era_and_reward_pool, BalanceOf, BoostingRewardsProvider,
+	ProviderBoostRewardClaim,
 };
 use common_primitives::{
 	node::{AccountId, Hash, ProposalProvider},
@@ -134,11 +134,11 @@ impl pallet_msa::Config for Test {
 }
 
 // not used yet
-pub struct TestStakingRewardsProvider {}
+pub struct TestRewardsProvider {}
 
 type TestRewardEra = u32;
 
-impl StakingRewardsProvider<Test> for TestStakingRewardsProvider {
+impl BoostingRewardsProvider<Test> for TestRewardsProvider {
 	type AccountId = u64;
 	type RewardEra = TestRewardEra;
 	type Hash = Hash; // use what's in common_primitives::node
@@ -173,7 +173,7 @@ impl StakingRewardsProvider<Test> for TestStakingRewardsProvider {
 	fn validate_staking_reward_claim(
 		_account_id: Self::AccountId,
 		_proof: Self::Hash,
-		_payload: StakingRewardClaim<Test>,
+		_payload: ProviderBoostRewardClaim<Test>,
 	) -> bool {
 		true
 	}
@@ -208,7 +208,7 @@ impl pallet_capacity::Config for Test {
 	type CapacityPerToken = TestCapacityPerToken;
 	type RewardEra = TestRewardEra;
 	type EraLength = ConstU32<10>;
-	type StakingRewardsPastErasMax = ConstU32<6>; // 5 for claiming rewards, 1 for current reward era
+	type ProviderBoostRewardsPastErasMax = ConstU32<6>; // 5 for claiming rewards, 1 for current reward era
 	type RewardsProvider = Capacity;
 	type MaxRetargetsPerRewardEra = ConstU32<5>;
 	type RewardPoolEachEra = ConstU64<10_000>;

--- a/pallets/capacity/src/tests/provider_boost_history_tests.rs
+++ b/pallets/capacity/src/tests/provider_boost_history_tests.rs
@@ -62,7 +62,7 @@ fn stake_does_not_add_to_staking_history() {
 #[test]
 fn provider_boost_history_add_era_balance_adds_entries_and_deletes_old_if_full() {
 	let mut pbh = ProviderBoostHistory::<Test>::new();
-	let bound: u32 = <Test as Config>::ProviderBoostRewardsPastErasMax::get();
+	let bound: u32 = <Test as Config>::ProviderBoostHistoryLimit::get();
 
 	for era in 1..bound + 1u32 {
 		let add_amount: u64 = 1_000 * era as u64;

--- a/pallets/capacity/src/tests/provider_boost_history_tests.rs
+++ b/pallets/capacity/src/tests/provider_boost_history_tests.rs
@@ -62,7 +62,7 @@ fn stake_does_not_add_to_staking_history() {
 #[test]
 fn provider_boost_history_add_era_balance_adds_entries_and_deletes_old_if_full() {
 	let mut pbh = ProviderBoostHistory::<Test>::new();
-	let bound: u32 = <Test as Config>::StakingRewardsPastErasMax::get();
+	let bound: u32 = <Test as Config>::ProviderBoostRewardsPastErasMax::get();
 
 	for era in 1..bound + 1u32 {
 		let add_amount: u64 = 1_000 * era as u64;

--- a/pallets/capacity/src/tests/rewards_provider_tests.rs
+++ b/pallets/capacity/src/tests/rewards_provider_tests.rs
@@ -1,8 +1,7 @@
 use super::mock::*;
 use crate::{
-	CurrentEraInfo, Error, ProviderBoostHistories, ProviderBoostHistory, RewardEraInfo,
-	StakingDetails, StakingRewardClaim, StakingRewardsProvider, StakingType::*,
-	UnclaimedRewardInfo,
+	BoostingRewardsProvider, CurrentEraInfo, Error, ProviderBoostHistories, ProviderBoostHistory,
+	ProviderBoostRewardClaim, RewardEraInfo, StakingDetails, StakingType::*, UnclaimedRewardInfo,
 };
 use frame_support::{assert_err, assert_ok, traits::Len};
 
@@ -19,7 +18,7 @@ fn staking_reward_total_happy_path() {
 		// this calls the implementation in the pallet
 		assert_eq!(Ok(5u64), Capacity::staking_reward_total(1, 5u32, 10u32));
 		let proof = H256::random();
-		let payload: StakingRewardClaim<Test> = StakingRewardClaim {
+		let payload: ProviderBoostRewardClaim<Test> = ProviderBoostRewardClaim {
 			claimed_reward: 1,
 			staking_account_end_state: StakingDetails { active: 1, staking_type: MaximumCapacity },
 			from_era: 1,

--- a/pallets/capacity/src/tests/rewards_provider_tests.rs
+++ b/pallets/capacity/src/tests/rewards_provider_tests.rs
@@ -1,7 +1,8 @@
 use super::mock::*;
 use crate::{
-	BoostingRewardsProvider, CurrentEraInfo, Error, ProviderBoostHistories, ProviderBoostHistory,
-	ProviderBoostRewardClaim, RewardEraInfo, StakingDetails, StakingType::*, UnclaimedRewardInfo,
+	CurrentEraInfo, Error, ProviderBoostHistories, ProviderBoostHistory, ProviderBoostRewardClaim,
+	ProviderBoostRewardsProvider, RewardEraInfo, StakingDetails, StakingType::*,
+	UnclaimedRewardInfo,
 };
 use frame_support::{assert_err, assert_ok, traits::Len};
 

--- a/pallets/capacity/src/tests/testing_utils.rs
+++ b/pallets/capacity/src/tests/testing_utils.rs
@@ -5,8 +5,8 @@ use frame_support::{assert_ok, traits::Hooks};
 use sp_runtime::traits::SignedExtension;
 
 use crate::{
-	BalanceOf, CapacityDetails, Config, CurrentEraInfo, Event, RewardEraInfo, RewardPoolInfo,
-	StakingRewardPool, StakingType,
+	BalanceOf, CapacityDetails, Config, CurrentEraInfo, Event, ProviderBoostRewardPool,
+	RewardEraInfo, RewardPoolInfo, StakingType,
 };
 use common_primitives::msa::MessageSourceId;
 
@@ -103,5 +103,5 @@ pub fn set_era_and_reward_pool(era_index: u32, started_at: u32, total_staked_tok
 		total_reward_pool,
 		unclaimed_balance: total_reward_pool,
 	};
-	StakingRewardPool::<Test>::insert(era_index, pool_info);
+	ProviderBoostRewardPool::<Test>::insert(era_index, pool_info);
 }

--- a/pallets/capacity/src/tests/unstaking_tests.rs
+++ b/pallets/capacity/src/tests/unstaking_tests.rs
@@ -441,7 +441,7 @@ fn get_amount_staked_for_era_works() {
 	assert_eq!(staking_history.get_amount_staked_for_era(&14u32), 13u64);
 
 	// querying for an era that has been cleared due to the hitting the bound
-	// (StakingRewardsPastErasMax = 5 in mock) returns zero.
+	// (ProviderBoostRewardsPastErasMax = 5 in mock) returns zero.
 	assert_eq!(staking_history.get_amount_staked_for_era(&9u32), 0u64);
 }
 

--- a/pallets/capacity/src/tests/unstaking_tests.rs
+++ b/pallets/capacity/src/tests/unstaking_tests.rs
@@ -441,7 +441,7 @@ fn get_amount_staked_for_era_works() {
 	assert_eq!(staking_history.get_amount_staked_for_era(&14u32), 13u64);
 
 	// querying for an era that has been cleared due to the hitting the bound
-	// (ProviderBoostRewardsPastErasMax = 5 in mock) returns zero.
+	// (ProviderBoostHistoryLimit = 5 in mock) returns zero.
 	assert_eq!(staking_history.get_amount_staked_for_era(&9u32), 0u64);
 }
 

--- a/pallets/capacity/src/types.rs
+++ b/pallets/capacity/src/types.rs
@@ -111,7 +111,7 @@ impl<Balance: Default + Saturating + Copy + CheckedAdd + CheckedSub + PartialOrd
 		self.amount = self.amount.saturating_sub(amount);
 		if self.amount.lt(&minimum) {
 			*self = Self::default();
-			return (entire_amount, entire_capacity)
+			return (entire_amount, entire_capacity);
 		} else {
 			self.capacity = self.capacity.saturating_sub(capacity);
 		}
@@ -290,7 +290,7 @@ pub struct RewardPoolInfo<Balance> {
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
 pub struct ProviderBoostHistory<T: Config>(
-	BoundedBTreeMap<T::RewardEra, BalanceOf<T>, T::ProviderBoostRewardsPastErasMax>,
+	BoundedBTreeMap<T::RewardEra, BalanceOf<T>, T::ProviderBoostHistoryLimit>,
 );
 
 impl<T: Config> Default for ProviderBoostHistory<T> {
@@ -362,7 +362,7 @@ impl<T: Config> ProviderBoostHistory<T> {
 				.try_insert(*reward_era, current_staking_amount.saturating_sub(*subtract_amount))
 				.is_err()
 			{
-				return None
+				return None;
 			}
 		}
 		Some(self.count())
@@ -384,7 +384,7 @@ impl<T: Config> ProviderBoostHistory<T> {
 		let mut eligible_amount: BalanceOf<T> = Zero::zero();
 		while let Some((era, balance)) = bmap_iter.next() {
 			if era.eq(reward_era) {
-				return *balance
+				return *balance;
 			}
 			// there was a boost or unstake in this era.
 			else if era.gt(reward_era) {
@@ -418,7 +418,7 @@ impl<T: Config> ProviderBoostHistory<T> {
 	}
 
 	fn is_full(&self) -> bool {
-		self.count().eq(&(T::ProviderBoostRewardsPastErasMax::get() as usize))
+		self.count().eq(&(T::ProviderBoostHistoryLimit::get() as usize))
 	}
 }
 
@@ -444,7 +444,7 @@ impl<T: Config> RetargetInfo<T> {
 	pub fn update(&mut self, current_era: T::RewardEra) -> Option<()> {
 		let max_retargets = T::MaxRetargetsPerRewardEra::get();
 		if self.retarget_count.ge(&max_retargets) && self.last_retarget_at.eq(&current_era) {
-			return None
+			return None;
 		}
 		if self.last_retarget_at.lt(&current_era) {
 			self.last_retarget_at = current_era;
@@ -469,7 +469,7 @@ pub struct ProviderBoostRewardClaim<T: Config> {
 }
 
 /// A trait that provides the Economic Model for Provider Boosting.
-pub trait BoostingRewardsProvider<T: Config> {
+pub trait ProviderBoostRewardsProvider<T: Config> {
 	/// the AccountId this provider is using
 	type AccountId;
 

--- a/pallets/capacity/src/types.rs
+++ b/pallets/capacity/src/types.rs
@@ -290,7 +290,7 @@ pub struct RewardPoolInfo<Balance> {
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
 pub struct ProviderBoostHistory<T: Config>(
-	BoundedBTreeMap<T::RewardEra, BalanceOf<T>, T::StakingRewardsPastErasMax>,
+	BoundedBTreeMap<T::RewardEra, BalanceOf<T>, T::ProviderBoostRewardsPastErasMax>,
 );
 
 impl<T: Config> Default for ProviderBoostHistory<T> {
@@ -418,7 +418,7 @@ impl<T: Config> ProviderBoostHistory<T> {
 	}
 
 	fn is_full(&self) -> bool {
-		self.count().eq(&(T::StakingRewardsPastErasMax::get() as usize))
+		self.count().eq(&(T::ProviderBoostRewardsPastErasMax::get() as usize))
 	}
 }
 
@@ -457,7 +457,7 @@ impl<T: Config> RetargetInfo<T> {
 }
 
 /// A claim to be rewarded `claimed_reward` in token value
-pub struct StakingRewardClaim<T: Config> {
+pub struct ProviderBoostRewardClaim<T: Config> {
 	/// How much is claimed, in token
 	pub claimed_reward: BalanceOf<T>,
 	/// The end state of the staking account if the operations are valid
@@ -469,7 +469,7 @@ pub struct StakingRewardClaim<T: Config> {
 }
 
 /// A trait that provides the Economic Model for Provider Boosting.
-pub trait StakingRewardsProvider<T: Config> {
+pub trait BoostingRewardsProvider<T: Config> {
 	/// the AccountId this provider is using
 	type AccountId;
 
@@ -494,7 +494,7 @@ pub trait StakingRewardsProvider<T: Config> {
 		to_era: Self::RewardEra,
 	) -> Result<BalanceOf<T>, DispatchError>;
 
-	/// Calculate the staking reward for a single era.  We don't care about the era number,
+	/// Calculate the reward for a single era.  We don't care about the era number,
 	/// just the values.
 	fn era_staking_reward(
 		era_amount_staked: BalanceOf<T>, // how much individual staked for a specific era
@@ -502,7 +502,7 @@ pub trait StakingRewardsProvider<T: Config> {
 		era_reward_pool_size: BalanceOf<T>, // how much token in the reward pool that era
 	) -> BalanceOf<T>;
 
-	/// Validate a payout claim for `accountId`, using `proof` and the provided `payload` StakingRewardClaim.
+	/// Validate a payout claim for `accountId`, using `proof` and the provided `payload` ProviderBoostRewardClaim.
 	/// Returns whether the claim passes validation.  Accounts must first pass `payoutEligible` test.
 	/// Errors:
 	///     - NotAStakingAccount
@@ -511,7 +511,7 @@ pub trait StakingRewardsProvider<T: Config> {
 	fn validate_staking_reward_claim(
 		account_id: Self::AccountId,
 		proof: Self::Hash,
-		payload: StakingRewardClaim<T>,
+		payload: ProviderBoostRewardClaim<T>,
 	) -> bool;
 
 	/// Return the effective amount when staked for a Provider Boost

--- a/pallets/capacity/src/weights.rs
+++ b/pallets/capacity/src/weights.rs
@@ -115,10 +115,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	/// Storage: `Capacity::StakingRewardPool` (r:3 w:2)
-	/// Proof: `Capacity::StakingRewardPool` (`max_values`: None, `max_size`: Some(60), added: 2535, mode: `MaxEncodedLen`)
-	/// Storage: `Capacity::CounterForStakingRewardPool` (r:1 w:1)
-	/// Proof: `Capacity::CounterForStakingRewardPool` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
+	/// Storage: `Capacity::ProviderBoostRewardPool` (r:3 w:2)
+	/// Proof: `Capacity::ProviderBoostRewardPool` (`max_values`: None, `max_size`: Some(60), added: 2535, mode: `MaxEncodedLen`)
+	/// Storage: `Capacity::CounterForProviderBoostRewardPool` (r:1 w:1)
+	/// Proof: `Capacity::CounterForProviderBoostRewardPool` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
 	fn start_new_reward_era_if_needed() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `613`
@@ -132,8 +132,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `Capacity::ProviderBoostHistories` (`max_values`: None, `max_size`: Some(661), added: 3136, mode: `MaxEncodedLen`)
 	/// Storage: `Capacity::StakingAccountLedger` (r:1 w:1)
 	/// Proof: `Capacity::StakingAccountLedger` (`max_values`: None, `max_size`: Some(57), added: 2532, mode: `MaxEncodedLen`)
-	/// Storage: `Capacity::StakingRewardPool` (r:1 w:1)
-	/// Proof: `Capacity::StakingRewardPool` (`max_values`: None, `max_size`: Some(60), added: 2535, mode: `MaxEncodedLen`)
+	/// Storage: `Capacity::ProviderBoostRewardPool` (r:1 w:1)
+	/// Proof: `Capacity::ProviderBoostRewardPool` (`max_values`: None, `max_size`: Some(60), added: 2535, mode: `MaxEncodedLen`)
 	/// Storage: `Capacity::UnstakeUnlocks` (r:1 w:1)
 	/// Proof: `Capacity::UnstakeUnlocks` (`max_values`: None, `max_size`: Some(121), added: 2596, mode: `MaxEncodedLen`)
 	/// Storage: `Capacity::StakingTargetLedger` (r:1 w:1)
@@ -186,8 +186,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `Capacity::StakingTargetLedger` (`max_values`: None, `max_size`: Some(88), added: 2563, mode: `MaxEncodedLen`)
 	/// Storage: `Capacity::CapacityLedger` (r:1 w:1)
 	/// Proof: `Capacity::CapacityLedger` (`max_values`: None, `max_size`: Some(68), added: 2543, mode: `MaxEncodedLen`)
-	/// Storage: `Capacity::StakingRewardPool` (r:1 w:1)
-	/// Proof: `Capacity::StakingRewardPool` (`max_values`: None, `max_size`: Some(60), added: 2535, mode: `MaxEncodedLen`)
+	/// Storage: `Capacity::ProviderBoostRewardPool` (r:1 w:1)
+	/// Proof: `Capacity::ProviderBoostRewardPool` (`max_values`: None, `max_size`: Some(60), added: 2535, mode: `MaxEncodedLen`)
 	/// Storage: `Capacity::UnstakeUnlocks` (r:1 w:0)
 	/// Proof: `Capacity::UnstakeUnlocks` (`max_values`: None, `max_size`: Some(121), added: 2596, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Freezes` (r:1 w:1)
@@ -262,10 +262,10 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
-	/// Storage: `Capacity::StakingRewardPool` (r:3 w:2)
-	/// Proof: `Capacity::StakingRewardPool` (`max_values`: None, `max_size`: Some(60), added: 2535, mode: `MaxEncodedLen`)
-	/// Storage: `Capacity::CounterForStakingRewardPool` (r:1 w:1)
-	/// Proof: `Capacity::CounterForStakingRewardPool` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
+	/// Storage: `Capacity::ProviderBoostRewardPool` (r:3 w:2)
+	/// Proof: `Capacity::ProviderBoostRewardPool` (`max_values`: None, `max_size`: Some(60), added: 2535, mode: `MaxEncodedLen`)
+	/// Storage: `Capacity::CounterForProviderBoostRewardPool` (r:1 w:1)
+	/// Proof: `Capacity::CounterForProviderBoostRewardPool` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
 	fn start_new_reward_era_if_needed() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `613`
@@ -279,8 +279,8 @@ impl WeightInfo for () {
 	/// Proof: `Capacity::ProviderBoostHistories` (`max_values`: None, `max_size`: Some(661), added: 3136, mode: `MaxEncodedLen`)
 	/// Storage: `Capacity::StakingAccountLedger` (r:1 w:1)
 	/// Proof: `Capacity::StakingAccountLedger` (`max_values`: None, `max_size`: Some(57), added: 2532, mode: `MaxEncodedLen`)
-	/// Storage: `Capacity::StakingRewardPool` (r:1 w:1)
-	/// Proof: `Capacity::StakingRewardPool` (`max_values`: None, `max_size`: Some(60), added: 2535, mode: `MaxEncodedLen`)
+	/// Storage: `Capacity::ProviderBoostRewardPool` (r:1 w:1)
+	/// Proof: `Capacity::ProviderBoostRewardPool` (`max_values`: None, `max_size`: Some(60), added: 2535, mode: `MaxEncodedLen`)
 	/// Storage: `Capacity::UnstakeUnlocks` (r:1 w:1)
 	/// Proof: `Capacity::UnstakeUnlocks` (`max_values`: None, `max_size`: Some(121), added: 2596, mode: `MaxEncodedLen`)
 	/// Storage: `Capacity::StakingTargetLedger` (r:1 w:1)
@@ -333,8 +333,8 @@ impl WeightInfo for () {
 	/// Proof: `Capacity::StakingTargetLedger` (`max_values`: None, `max_size`: Some(88), added: 2563, mode: `MaxEncodedLen`)
 	/// Storage: `Capacity::CapacityLedger` (r:1 w:1)
 	/// Proof: `Capacity::CapacityLedger` (`max_values`: None, `max_size`: Some(68), added: 2543, mode: `MaxEncodedLen`)
-	/// Storage: `Capacity::StakingRewardPool` (r:1 w:1)
-	/// Proof: `Capacity::StakingRewardPool` (`max_values`: None, `max_size`: Some(60), added: 2535, mode: `MaxEncodedLen`)
+	/// Storage: `Capacity::ProviderBoostRewardPool` (r:1 w:1)
+	/// Proof: `Capacity::ProviderBoostRewardPool` (`max_values`: None, `max_size`: Some(60), added: 2535, mode: `MaxEncodedLen`)
 	/// Storage: `Capacity::UnstakeUnlocks` (r:1 w:0)
 	/// Proof: `Capacity::UnstakeUnlocks` (`max_values`: None, `max_size`: Some(121), added: 2596, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Freezes` (r:1 w:1)

--- a/pallets/frequency-tx-payment/src/tests/mock.rs
+++ b/pallets/frequency-tx-payment/src/tests/mock.rs
@@ -220,7 +220,7 @@ impl pallet_capacity::Config for Test {
 	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type RewardEra = u32;
 	type EraLength = ConstU32<5>;
-	type StakingRewardsPastErasMax = ConstU32<2>;
+	type ProviderBoostRewardsPastErasMax = ConstU32<2>;
 	type RewardsProvider = Capacity;
 	type MaxRetargetsPerRewardEra = ConstU32<5>;
 	type RewardPoolEachEra = ConstU64<10_000>;

--- a/pallets/frequency-tx-payment/src/tests/mock.rs
+++ b/pallets/frequency-tx-payment/src/tests/mock.rs
@@ -220,7 +220,7 @@ impl pallet_capacity::Config for Test {
 	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type RewardEra = u32;
 	type EraLength = ConstU32<5>;
-	type ProviderBoostRewardsPastErasMax = ConstU32<2>;
+	type ProviderBoostHistoryLimit = ConstU32<2>;
 	type RewardsProvider = Capacity;
 	type MaxRetargetsPerRewardEra = ConstU32<5>;
 	type RewardPoolEachEra = ConstU64<10_000>;
@@ -241,7 +241,7 @@ impl GetStableWeight<RuntimeCall, Weight> for TestCapacityCalls {
 	}
 
 	fn get_inner_calls(_call: &RuntimeCall) -> Option<Vec<&RuntimeCall>> {
-		return Some(vec![&RuntimeCall::Msa(pallet_msa::Call::create {})])
+		return Some(vec![&RuntimeCall::Msa(pallet_msa::Call::create {})]);
 	}
 }
 

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -561,7 +561,7 @@ impl pallet_capacity::Config for Runtime {
 	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type RewardEra = u32;
 	type EraLength = ConstU32<{ 14 * DAYS }>;
-	type StakingRewardsPastErasMax = ConstU32<31u32>; // 30 for claiming rewards, 1 for current era
+	type ProviderBoostRewardsPastErasMax = ConstU32<31u32>; // 30 for claiming rewards, 1 for current era
 	type RewardsProvider = Capacity;
 	type MaxRetargetsPerRewardEra = ConstU32<16>;
 	// Value determined by desired inflation rate limits for chosen economic model

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -124,16 +124,18 @@ impl Contains<RuntimeCall> for BaseCallFilter {
 		#[cfg(not(feature = "frequency"))]
 		{
 			match call {
-				RuntimeCall::Utility(pallet_utility_call) =>
-					Self::is_utility_call_allowed(pallet_utility_call),
+				RuntimeCall::Utility(pallet_utility_call) => {
+					Self::is_utility_call_allowed(pallet_utility_call)
+				},
 				_ => true,
 			}
 		}
 		#[cfg(feature = "frequency")]
 		{
 			match call {
-				RuntimeCall::Utility(pallet_utility_call) =>
-					Self::is_utility_call_allowed(pallet_utility_call),
+				RuntimeCall::Utility(pallet_utility_call) => {
+					Self::is_utility_call_allowed(pallet_utility_call)
+				},
 				// Create provider and create schema are not allowed in mainnet for now. See propose functions.
 				RuntimeCall::Msa(pallet_msa::Call::create_provider { .. }) => false,
 				RuntimeCall::Schemas(pallet_schemas::Call::create_schema { .. }) => false,
@@ -149,9 +151,11 @@ impl Contains<RuntimeCall> for BaseCallFilter {
 impl BaseCallFilter {
 	fn is_utility_call_allowed(call: &pallet_utility::Call<Runtime>) -> bool {
 		match call {
-			pallet_utility::Call::batch { calls, .. } |
-			pallet_utility::Call::batch_all { calls, .. } |
-			pallet_utility::Call::force_batch { calls, .. } => calls.iter().any(Self::is_batch_call_allowed),
+			pallet_utility::Call::batch { calls, .. }
+			| pallet_utility::Call::batch_all { calls, .. }
+			| pallet_utility::Call::force_batch { calls, .. } => {
+				calls.iter().any(Self::is_batch_call_allowed)
+			},
 			_ => true,
 		}
 	}
@@ -159,17 +163,17 @@ impl BaseCallFilter {
 	fn is_batch_call_allowed(call: &RuntimeCall) -> bool {
 		match call {
 			// Block all nested `batch` calls from utility batch
-			RuntimeCall::Utility(pallet_utility::Call::batch { .. }) |
-			RuntimeCall::Utility(pallet_utility::Call::batch_all { .. }) |
-			RuntimeCall::Utility(pallet_utility::Call::force_batch { .. }) => false,
+			RuntimeCall::Utility(pallet_utility::Call::batch { .. })
+			| RuntimeCall::Utility(pallet_utility::Call::batch_all { .. })
+			| RuntimeCall::Utility(pallet_utility::Call::force_batch { .. }) => false,
 
 			// Block all `FrequencyTxPayment` calls from utility batch
 			RuntimeCall::FrequencyTxPayment(..) => false,
 
 			// Block `create_provider` and `create_schema` calls from utility batch
-			RuntimeCall::Msa(pallet_msa::Call::create_provider { .. }) |
-			RuntimeCall::Schemas(pallet_schemas::Call::create_schema { .. }) |
-			RuntimeCall::Schemas(pallet_schemas::Call::create_schema_v2 { .. }) => false,
+			RuntimeCall::Msa(pallet_msa::Call::create_provider { .. })
+			| RuntimeCall::Schemas(pallet_schemas::Call::create_schema { .. })
+			| RuntimeCall::Schemas(pallet_schemas::Call::create_schema_v2 { .. }) => false,
 			RuntimeCall::Schemas(pallet_schemas::Call::create_schema_v3 { .. }) => false,
 
 			// Block `Pays::No` calls from utility batch
@@ -221,17 +225,17 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 			),
 			ProxyType::Governance => matches!(
 				c,
-				RuntimeCall::Treasury(..) |
-					RuntimeCall::Democracy(..) |
-					RuntimeCall::TechnicalCommittee(..) |
-					RuntimeCall::Council(..) |
-					RuntimeCall::Utility(..) // Calls inside a batch are also run through filters
+				RuntimeCall::Treasury(..)
+					| RuntimeCall::Democracy(..)
+					| RuntimeCall::TechnicalCommittee(..)
+					| RuntimeCall::Council(..)
+					| RuntimeCall::Utility(..) // Calls inside a batch are also run through filters
 			),
 			ProxyType::Staking => {
 				matches!(
 					c,
-					RuntimeCall::Capacity(pallet_capacity::Call::stake { .. }) |
-						RuntimeCall::CollatorSelection(
+					RuntimeCall::Capacity(pallet_capacity::Call::stake { .. })
+						| RuntimeCall::CollatorSelection(
 							pallet_collator_selection::Call::set_candidacy_bond { .. }
 						)
 				)
@@ -315,48 +319,48 @@ impl<
 {
 	fn on_runtime_upgrade() -> Weight {
 		let mut writes = 0u64;
-		if pallet_preimage::Pallet::<T>::on_chain_storage_version() !=
-			pallet_preimage::Pallet::<T>::current_storage_version()
+		if pallet_preimage::Pallet::<T>::on_chain_storage_version()
+			!= pallet_preimage::Pallet::<T>::current_storage_version()
 		{
 			pallet_preimage::Pallet::<T>::current_storage_version()
 				.put::<pallet_preimage::Pallet<T>>();
 			writes += 1;
 			log::info!("Setting version on pallet_preimage");
 		}
-		if pallet_democracy::Pallet::<T>::on_chain_storage_version() !=
-			pallet_democracy::Pallet::<T>::current_storage_version()
+		if pallet_democracy::Pallet::<T>::on_chain_storage_version()
+			!= pallet_democracy::Pallet::<T>::current_storage_version()
 		{
 			pallet_democracy::Pallet::<T>::current_storage_version()
 				.put::<pallet_democracy::Pallet<T>>();
 			writes += 1;
 			log::info!("Setting version on pallet_democracy");
 		}
-		if pallet_scheduler::Pallet::<T>::on_chain_storage_version() !=
-			pallet_scheduler::Pallet::<T>::current_storage_version()
+		if pallet_scheduler::Pallet::<T>::on_chain_storage_version()
+			!= pallet_scheduler::Pallet::<T>::current_storage_version()
 		{
 			pallet_scheduler::Pallet::<T>::current_storage_version()
 				.put::<pallet_scheduler::Pallet<T>>();
 			writes += 1;
 			log::info!("Setting version on pallet_scheduler");
 		}
-		if pallet_balances::Pallet::<T>::on_chain_storage_version() !=
-			pallet_balances::Pallet::<T>::current_storage_version()
+		if pallet_balances::Pallet::<T>::on_chain_storage_version()
+			!= pallet_balances::Pallet::<T>::current_storage_version()
 		{
 			pallet_balances::Pallet::<T>::current_storage_version()
 				.put::<pallet_balances::Pallet<T>>();
 			writes += 1;
 			log::info!("Setting version on pallet_balances");
 		}
-		if pallet_collator_selection::Pallet::<T>::on_chain_storage_version() !=
-			pallet_collator_selection::Pallet::<T>::current_storage_version()
+		if pallet_collator_selection::Pallet::<T>::on_chain_storage_version()
+			!= pallet_collator_selection::Pallet::<T>::current_storage_version()
 		{
 			pallet_collator_selection::Pallet::<T>::current_storage_version()
 				.put::<pallet_collator_selection::Pallet<T>>();
 			writes += 1;
 			log::info!("Setting version on pallet_collator_selection");
 		}
-		if pallet_multisig::Pallet::<T>::on_chain_storage_version() !=
-			pallet_multisig::Pallet::<T>::current_storage_version()
+		if pallet_multisig::Pallet::<T>::on_chain_storage_version()
+			!= pallet_multisig::Pallet::<T>::current_storage_version()
 		{
 			pallet_multisig::Pallet::<T>::current_storage_version()
 				.put::<pallet_multisig::Pallet<T>>();
@@ -561,7 +565,7 @@ impl pallet_capacity::Config for Runtime {
 	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type RewardEra = u32;
 	type EraLength = ConstU32<{ 14 * DAYS }>;
-	type ProviderBoostRewardsPastErasMax = ConstU32<31u32>; // 30 for claiming rewards, 1 for current era
+	type ProviderBoostHistoryLimit = ConstU32<31u32>; // 30 for claiming rewards, 1 for current era
 	type RewardsProvider = Capacity;
 	type MaxRetargetsPerRewardEra = ConstU32<16>;
 	// Value determined by desired inflation rate limits for chosen economic model


### PR DESCRIPTION
# Goal
The goal of this PR is to unify naming for the Provider Boost feature.  Everything that was called St*ing Rewards is now ProviderBoost or Boosting Rewards

Part of #1976 

# Discussion
Only renames.  Also seeking alternate suggestions.
