### PR TITLE
Output the compressed wasm, not the uncompressed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -324,7 +324,7 @@ jobs:
           runtime_dir: ${{ matrix.runtime-dir }}
       - name: Rename WASM file
         run: |
-          cp -p ${{ steps.srtool_build.outputs.wasm }} \
+          cp -p ${{ steps.srtool_build.outputs.wasm_compressed }} \
             ./${{env.WASM_DIR}}/${{env.RELEASE_WASM_FILENAME}}
       - name: Install Subwasm
         run: |


### PR DESCRIPTION
# Goal
The goal of this PR is use the compressed wasm instead of the uncompressed wasm in the releases.

When reviewing the v1.12.0 release, it was discovered that the srtool output for the wasm instead of the compressed wasm was being used.

This corrects that error by using the correct output from the srtool workflow

![image](https://github.com/frequency-chain/frequency/assets/1252199/c4a2b839-3ccd-44e9-82aa-860d1fc01f82)
