### PR TITLE
E2e for new extrinsics

### DIFF
--- a/e2e/capacity/change_staking_target.test.ts
+++ b/e2e/capacity/change_staking_target.test.ts
@@ -1,54 +1,41 @@
 import "@frequency-chain/api-augment";
-import { KeyringPair } from "@polkadot/keyring/types";
-import { u64, } from "@polkadot/types";
 import assert from "assert";
 import { ExtrinsicHelper, } from "../scaffolding/extrinsicHelpers";
+import { getFundingSource } from '../scaffolding/funding';
 import {
-  devAccounts, createKeys, createMsaAndProvider,
-  stakeToProvider, CHAIN_ENVIRONMENT,
-  TEST_EPOCH_LENGTH, setEpochLength,
+  createKeys, createMsaAndProvider,
+  stakeToProvider,
   CENTS, DOLLARS, createAndFundKeypair, createProviderKeysAndId
-}
-  from "../scaffolding/helpers";
-import { firstValueFrom } from "rxjs";
-import { MessageSourceId} from "@frequency-chain/api-augment/interfaces";
+} from "../scaffolding/helpers";
 
-describe("change_staking_target tests", () => {
+const fundingSource = getFundingSource('capacity-replenishment');
+
+describe("Capacity: change_staking_target", function() {
   const tokenMinStake: bigint = 1n * CENTS;
   const capacityMin: bigint = tokenMinStake / 50n;
 
-  const unusedMsaId = async () => {
-    const maxMsaId = (await ExtrinsicHelper.getCurrentMsaIdentifierMaximum()).toNumber();
-    return maxMsaId + 99;
-  }
-
-  before(async () => {
-    if (process.env.CHAIN_ENVIRONMENT === CHAIN_ENVIRONMENT.DEVELOPMENT) {
-      await setEpochLength(devAccounts[0].keys, TEST_EPOCH_LENGTH);
-    }
-  });
-
-  it("happy path succeeds", async () => {
+  it("happy path succeeds", async function() {
       const providerBalance = 2n * DOLLARS;
       const stakeKeys = createKeys("staker");
-      const oldProvider = await createMsaAndProvider(stakeKeys, "Provider1", providerBalance);
-      const [_unused, newProvider] = await createProviderKeysAndId();
+      const oldProvider = await createMsaAndProvider(fundingSource, stakeKeys, "Provider1", providerBalance);
+      const [_bar, newProvider] = await createProviderKeysAndId(fundingSource, providerBalance);
 
-      await assert.doesNotReject(stakeToProvider(stakeKeys, oldProvider, tokenMinStake*3n));
+      await assert.doesNotReject(stakeToProvider(fundingSource, stakeKeys, oldProvider, tokenMinStake*3n));
 
       const call = ExtrinsicHelper.changeStakingTarget(stakeKeys, oldProvider, newProvider, tokenMinStake);
-      const [events] = await call.signAndSend();
+      const events = await call.signAndSend();
       assert.notEqual(events, undefined);
   });
 
   // not intended to be exhaustive, just check one error case
-  it("fails if 'to' is not a Provider", async () => {
+  it("fails if 'to' is not a Provider", async function() {
     const providerBalance = 2n * DOLLARS;
     const stakeKeys = createKeys("staker");
-    const notAProvider = await unusedMsaId();
-    const oldProvider = await createMsaAndProvider(stakeKeys, "Provider1", providerBalance);
-    await assert.doesNotReject(stakeToProvider(stakeKeys, oldProvider, tokenMinStake*3n));
-    const call = ExtrinsicHelper.changeStakingTarget(stakeKeys, oldProvider, notAProvider, tokenMinStake);
-    await assert.rejects(call.signAndSend(), {name: "InvalidTarget"})
+    const oldProvider = await createMsaAndProvider(fundingSource, stakeKeys, "Provider2", providerBalance);
+
+    await assert.doesNotReject(stakeToProvider(fundingSource, stakeKeys, oldProvider, tokenMinStake*3n));
+    // const notAProvider = 3;
+    // const call = ExtrinsicHelper.changeStakingTarget(stakeKeys, oldProvider, notAProvider, tokenMinStake);
+    // await assert.rejects(call.signAndSend(), {name: "InvalidTarget"})
   });
 });

--- a/e2e/capacity/change_staking_target.test.ts
+++ b/e2e/capacity/change_staking_target.test.ts
@@ -34,8 +34,8 @@ describe("Capacity: change_staking_target", function() {
     const oldProvider = await createMsaAndProvider(fundingSource, stakeKeys, "Provider2", providerBalance);
 
     await assert.doesNotReject(stakeToProvider(fundingSource, stakeKeys, oldProvider, tokenMinStake*3n));
-    // const notAProvider = 3;
-    // const call = ExtrinsicHelper.changeStakingTarget(stakeKeys, oldProvider, notAProvider, tokenMinStake);
-    // await assert.rejects(call.signAndSend(), {name: "InvalidTarget"})
+    const notAProvider = 3;
+    const call = ExtrinsicHelper.changeStakingTarget(stakeKeys, oldProvider, notAProvider, tokenMinStake);
+    await assert.rejects(call.signAndSend(), {name: "InvalidTarget"})
   });
 });

--- a/e2e/capacity/provider_boost.test.ts
+++ b/e2e/capacity/provider_boost.test.ts
@@ -1,0 +1,42 @@
+import "@frequency-chain/api-augment";
+import assert from "assert";
+import { getFundingSource } from '../scaffolding/funding';
+import {
+  createKeys, createMsaAndProvider,
+  CENTS, DOLLARS, createAndFundKeypair, boostProvider,
+} from '../scaffolding/helpers';
+
+const fundingSource = getFundingSource('capacity-replenishment');
+
+describe("Capacity: provider_boost extrinsic", function() {
+  const providerBalance = 2n * DOLLARS;
+
+  it("happy path succeeds", async function () {
+    const stakeKeys = createKeys("booster");
+    const provider = await createMsaAndProvider(fundingSource, stakeKeys, "Provider1", providerBalance);
+    const booster = await createAndFundKeypair(fundingSource, 5n * DOLLARS, "booster");
+    await assert.doesNotReject(boostProvider(fundingSource, booster, provider, 1n * DOLLARS));
+  });
+
+  it("fails when they are a Maximized Capacity staker", async function() {
+    const stakeKeys = createKeys("booster");
+    const provider = await createMsaAndProvider(fundingSource, stakeKeys, "Provider1", providerBalance);
+    await assert.rejects(boostProvider(fundingSource, stakeKeys, provider, 1n * DOLLARS));
+  });
+
+  it("fails when they don't have enough token", async function() {
+    const stakeKeys = createKeys("booster");
+    const provider = await createMsaAndProvider(fundingSource, stakeKeys, "Provider1", providerBalance);
+    const booster = await createAndFundKeypair(fundingSource, 1n * DOLLARS, "booster");
+    await assert.rejects(boostProvider(booster, booster, provider, 1n * DOLLARS));
+  });
+
+  it("they can boost multiple times", async function () {
+    const stakeKeys = createKeys("booster");
+    const provider = await createMsaAndProvider(fundingSource, stakeKeys, "Provider1", providerBalance);
+    const booster = await createAndFundKeypair(fundingSource, 10n * DOLLARS, "booster");
+    await assert.doesNotReject(boostProvider(fundingSource, booster, provider, 1n * DOLLARS));
+    await assert.doesNotReject(boostProvider(fundingSource, booster, provider, 1n * DOLLARS));
+    await assert.doesNotReject(boostProvider(fundingSource, booster, provider, 1n * DOLLARS));
+  });
+});

--- a/e2e/capacity/replenishment.test.ts
+++ b/e2e/capacity/replenishment.test.ts
@@ -23,7 +23,6 @@ import { isTestnet } from '../scaffolding/env';
 const fundingSource = getFundingSource('capacity-replenishment');
 
 describe('Capacity Replenishment Testing: ', function () {
-  let schemaId: u16;
 
   async function createAndStakeProvider(name: string, stakingAmount: bigint): Promise<[KeyringPair, u64]> {
     const stakeKeys = createKeys(name);
@@ -37,11 +36,11 @@ describe('Capacity Replenishment Testing: ', function () {
     // Replenishment requires the epoch length to be shorter than testnet (set in globalHooks)
     if (isTestnet()) this.skip();
 
-    schemaId = await getOrCreateGraphChangeSchema(fundingSource);
   });
 
   describe('Capacity is replenished', function () {
     it('after new epoch', async function () {
+      const schemaId = await getOrCreateGraphChangeSchema(fundingSource);
       const totalStaked = 3n * DOLLARS;
       const expectedCapacity = totalStaked / TokenPerCapacity;
       const [stakeKeys, stakeProviderId] = await createAndStakeProvider('ReplFirst', totalStaked);
@@ -84,6 +83,7 @@ describe('Capacity Replenishment Testing: ', function () {
 
   describe('Capacity is not replenished', function () {
     it('if out of capacity and last_replenished_at is <= current epoch', async function () {
+      const schemaId = await getOrCreateGraphChangeSchema(fundingSource);
       const [stakeKeys, stakeProviderId] = await createAndStakeProvider('NoSend', 150n * CENTS);
       const payload = JSON.stringify({ changeType: 1, fromId: 1, objectId: 2 });
       const call = ExtrinsicHelper.addOnChainMessage(stakeKeys, schemaId, payload);
@@ -108,6 +108,7 @@ describe('Capacity Replenishment Testing: ', function () {
       const { eventMap } = await ExtrinsicHelper.stake(userKeys, stakeProviderId, userStakeAmt).signAndSend();
       assertEvent(eventMap, 'system.ExtrinsicSuccess');
 
+      const schemaId = await getOrCreateGraphChangeSchema(fundingSource);
       const payload = JSON.stringify({ changeType: 1, fromId: 1, objectId: 2 });
       const call = ExtrinsicHelper.addOnChainMessage(stakeKeys, schemaId, payload);
 

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -2801,8 +2801,7 @@
     "node_modules/@frequency-chain/api-augment": {
       "version": "0.0.0",
       "resolved": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
-      "integrity": "sha512-/Us3KuGyVRQTSz1XAAINyl2QIzXIZadkg0lwyjSNvtQ2FiCV8MqFO16KN6vO94TSfnGa3QHsve+qRZPf6TACqw==",
-      "license": "Apache-2.0",
+      "integrity": "sha512-cMFstWAVmC+gyZ5JksCDfqO5vijIa2ltRyJ+irsNBqTta0I57QRXR1dc+yq6dSfdKHeVdfErDvb/WJ1NgOTG1w==",
       "dependencies": {
         "@polkadot/api": "^11.2.1",
         "@polkadot/rpc-provider": "^11.2.1",

--- a/e2e/scaffolding/extrinsicHelpers.ts
+++ b/e2e/scaffolding/extrinsicHelpers.ts
@@ -806,6 +806,22 @@ export class ExtrinsicHelper {
     );
   }
 
+  public static providerBoost(keys: KeyringPair, target: any, amount: any) {
+    return new Extrinsic(
+      () => ExtrinsicHelper.api.tx.capacity.providerBoost(target, amount),
+      keys,
+      ExtrinsicHelper.api.events.capacity.ProviderBoosted
+    );
+  }
+
+  public static changeStakingTarget(keys: KeyringPair, from: any, to: any, amount: any) {
+    return new Extrinsic(
+      () => ExtrinsicHelper.api.tx.capacity.changeStakingTarget(from, to, amount),
+      keys,
+      ExtrinsicHelper.api.events.capacity.StakingTargetChanged
+    );
+  }
+
   public static payWithCapacityBatchAll(keys: KeyringPair, calls: any) {
     return new Extrinsic(
       () => ExtrinsicHelper.api.tx.frequencyTxPayment.payWithCapacityBatchAll(calls),

--- a/e2e/scaffolding/helpers.ts
+++ b/e2e/scaffolding/helpers.ts
@@ -428,7 +428,6 @@ export async function stakeToProvider(
   if (stakeEvent) {
     const stakedCapacity = stakeEvent.data.capacity;
 
-    // let capacityCost: bigint = ExtrinsicHelper.api.consts.capacity.capacityPerToken.toBigInt();
     const expectedCapacity = tokensToStake / TokenPerCapacity;
 
     assert.equal(
@@ -454,7 +453,6 @@ export async function boostProvider(
   if (stakeEvent) {
     const stakedCapacity = stakeEvent.data.capacity;
 
-    // let capacityCost: bigint = ExtrinsicHelper.api.consts.capacity.capacityPerToken.toBigInt();
     const expectedCapacity = tokensToStake / TokenPerCapacity / BoostAdjustment;
 
     assert.equal(


### PR DESCRIPTION
# Goal
The goal of this PR is to add some e2e tests for the `provider_boost` extrinsic, and update the `change_staking_target` extrinsic after a rebase with main.

# Discussion
This breaks off a piece of the draft PR #2065 

# Checklist
- [x] Tests added
