### PR TITLE
Refactor reward era

### DIFF
--- a/common/primitives/src/capacity.rs
+++ b/common/primitives/src/capacity.rs
@@ -2,6 +2,9 @@ use crate::msa::MessageSourceId;
 use frame_support::traits::tokens::Balance;
 use sp_runtime::DispatchError;
 
+/// The type of a Reward Era
+pub type RewardEra = u32;
+
 /// A trait for checking that a target MSA can be staked to.
 pub trait TargetValidator {
 	/// Checks if an MSA is a valid target.

--- a/e2e/capacity/change_staking_target.test.ts
+++ b/e2e/capacity/change_staking_target.test.ts
@@ -33,9 +33,15 @@ describe("Capacity: change_staking_target", function() {
     const stakeKeys = createKeys("staker");
     const oldProvider = await createMsaAndProvider(fundingSource, stakeKeys, "Provider2", providerBalance);
 
-    await assert.doesNotReject(stakeToProvider(fundingSource, stakeKeys, oldProvider, tokenMinStake*3n));
-    const notAProvider = 3;
-    const call = ExtrinsicHelper.changeStakingTarget(stakeKeys, oldProvider, notAProvider, tokenMinStake);
-    await assert.rejects(call.signAndSend(), {name: "InvalidTarget"})
+    await assert.doesNotReject(stakeToProvider(fundingSource, stakeKeys, oldProvider, tokenMinStake*6n));
+    const notAProvider = 9999;
+    const call = ExtrinsicHelper.changeStakingTarget(stakeKeys, oldProvider, notAProvider, tokenMinStake*2n);
+    await assert.rejects(call.signAndSend(),
+      (err) => {
+        assert. strictEqual(err?.name, 'InvalidTarget', `expected InvalidTarget, got ${err?.name}`);
+        // // {name: "InvalidTarget"}
+        // assert. strictEqual(err?.message, `Wrong value: expected`);
+        return true;
+    });
   });
 });

--- a/pallets/capacity/src/benchmarking.rs
+++ b/pallets/capacity/src/benchmarking.rs
@@ -1,9 +1,10 @@
 use super::*;
 use crate::Pallet as Capacity;
 
+use crate::StakingType::*;
 use frame_benchmarking::{account, benchmarks, whitelist_account};
 use frame_support::{assert_ok, BoundedVec};
-use frame_system::RawOrigin;
+use frame_system::{pallet_prelude::BlockNumberFor, RawOrigin};
 use parity_scale_codec::alloc::vec::Vec;
 
 const SEED: u32 = 0;
@@ -38,11 +39,11 @@ pub fn set_up_epoch<T: Config>(current_block: BlockNumberFor<T>, current_epoch: 
 }
 
 pub fn set_era_and_reward_pool_at_block<T: Config>(
-	era_index: T::RewardEra,
+	era_index: RewardEra,
 	started_at: BlockNumberFor<T>,
 	total_staked_token: BalanceOf<T>,
 ) {
-	let era_info: RewardEraInfo<T::RewardEra, BlockNumberFor<T>> =
+	let era_info: RewardEraInfo<RewardEra, BlockNumberFor<T>> =
 		RewardEraInfo { era_index, started_at };
 	CurrentEraInfo::<T>::set(era_info);
 	CurrentEraProviderBoostTotal::<T>::set(total_staked_token)
@@ -149,7 +150,7 @@ benchmarks! {
 		let total_staked_token: BalanceOf<T> = 5_000u32.into();
 		let started_at: BlockNumberFor<T> = current_block.saturating_sub(<T as Config>::EraLength::get().into());
 
-		let current_era: T::RewardEra = (history_limit + 1u32).into();
+		let current_era: RewardEra = (history_limit + 1u32).into();
 		CurrentEraInfo::<T>::set(RewardEraInfo{ era_index: current_era, started_at });
 		fill_reward_pool_chunks::<T>();
 	}: {

--- a/pallets/capacity/src/migration/provider_boost_init.rs
+++ b/pallets/capacity/src/migration/provider_boost_init.rs
@@ -4,6 +4,7 @@ use frame_support::{
 	traits::{Get, OnRuntimeUpgrade},
 };
 
+use common_primitives::capacity::RewardEra;
 #[cfg(feature = "try-runtime")]
 use sp_std::vec::Vec;
 
@@ -15,7 +16,7 @@ impl<T: Config> OnRuntimeUpgrade for ProviderBoostInit<T> {
 		let current_era_info = CurrentEraInfo::<T>::get(); // 1r
 		if current_era_info.eq(&RewardEraInfo::default()) {
 			let current_block = frame_system::Pallet::<T>::block_number(); // Whitelisted
-			let era_index: T::RewardEra = 1u32.into();
+			let era_index: RewardEra = 1u32.into();
 			CurrentEraInfo::<T>::set(RewardEraInfo { era_index, started_at: current_block }); // 1w
 			CurrentEraProviderBoostTotal::<T>::set(0u32.into()); // 1w
 			T::DbWeight::get().reads_writes(2, 1)

--- a/pallets/capacity/src/tests/change_staking_target_tests.rs
+++ b/pallets/capacity/src/tests/change_staking_target_tests.rs
@@ -1,8 +1,8 @@
 use super::{
 	mock::*,
-	testing_utils::{setup_provider, staking_events},
+	testing_utils::{capacity_events, setup_provider},
 };
-use crate::*;
+use crate::{StakingType::*, *};
 use common_primitives::msa::MessageSourceId;
 use frame_support::{assert_noop, assert_ok, traits::Get};
 
@@ -229,7 +229,7 @@ fn change_staking_starget_emits_event_on_success() {
 			to_msa,
 			to_amount
 		));
-		let events = staking_events();
+		let events = capacity_events();
 
 		assert_eq!(
 			events.last().unwrap(),
@@ -425,7 +425,7 @@ fn impl_retarget_info_errors_when_attempt_to_update_past_bounded_max() {
 			TestCase { era: 1u32, retargets: 5u32, last_retarget: 1, expected: None },
 		] {
 			let mut retarget_info: RetargetInfo<Test> =
-				RetargetInfo { retarget_count: tc.retargets, last_retarget_at: tc.last_retarget };
+				RetargetInfo::new(tc.retargets, tc.last_retarget);
 			assert_eq!(retarget_info.update(tc.era), tc.expected);
 		}
 	})
@@ -448,7 +448,7 @@ fn impl_retarget_info_updates_values_correctly() {
 			TestCase { era: 1, retargets: 5, last_retarget: 1, expected_retargets: 5 },
 		] {
 			let mut retarget_info: RetargetInfo<Test> =
-				RetargetInfo { retarget_count: tc.retargets, last_retarget_at: tc.last_retarget };
+				RetargetInfo::new(tc.retargets, tc.last_retarget);
 			retarget_info.update(tc.era);
 			assert_eq!(retarget_info.retarget_count, tc.expected_retargets);
 		}
@@ -459,10 +459,9 @@ fn impl_retarget_info_updates_values_correctly() {
 fn impl_retarget_chunks_cleanup_when_new_reward_era() {
 	new_test_ext().execute_with(|| {
 		let current_era = 2u32;
-		let mut retarget_info: RetargetInfo<Test> =
-			RetargetInfo { retarget_count: 5, last_retarget_at: 1 };
+		let mut retarget_info: RetargetInfo<Test> = RetargetInfo::new(5, 1);
 		assert!(retarget_info.update(current_era).is_some());
-		let expected: RetargetInfo<Test> = RetargetInfo { retarget_count: 1, last_retarget_at: 2 };
+		let expected: RetargetInfo<Test> = RetargetInfo::new(1, 2);
 		assert_eq!(retarget_info, expected);
 	});
 }

--- a/pallets/capacity/src/tests/eras_tests.rs
+++ b/pallets/capacity/src/tests/eras_tests.rs
@@ -1,9 +1,8 @@
 use super::mock::*;
 use crate::{
-	tests::testing_utils::*, BalanceOf, Config, CurrentEraInfo, CurrentEraProviderBoostTotal,
-	RewardEraInfo,
+	tests::testing_utils::*, BalanceOf, CurrentEraInfo, CurrentEraProviderBoostTotal, RewardEraInfo,
 };
-use common_primitives::msa::MessageSourceId;
+use common_primitives::{capacity::RewardEra, msa::MessageSourceId};
 use frame_support::assert_ok;
 
 pub fn boost_provider_and_run_to_end_of_era(
@@ -44,7 +43,7 @@ fn start_new_era_if_needed_updates_era_info() {
 fn assert_chunk_is_full_and_has_earliest_era_total(
 	chunk_index: u32,
 	is_full: bool,
-	era: <Test as Config>::RewardEra,
+	era: RewardEra,
 	total: BalanceOf<Test>,
 ) {
 	let chunk = Capacity::get_reward_pool_chunk(chunk_index).unwrap();
@@ -55,7 +54,7 @@ fn assert_chunk_is_full_and_has_earliest_era_total(
 
 // gets the last (i.e. latest non-current) stored reward pool era, which is in chunk 0.
 // asserts that it is the same as `era`, and that it has amount `total`
-fn assert_last_era_total(era: <Test as Config>::RewardEra, total: BalanceOf<Test>) {
+fn assert_last_era_total(era: RewardEra, total: BalanceOf<Test>) {
 	let chunk_idx = Capacity::get_chunk_index_for_era(era);
 	let chunk_opt = Capacity::get_reward_pool_chunk(chunk_idx);
 	assert!(chunk_opt.is_some(), "No pool for Era: {:?} with chunk index: {:?}", era, chunk_idx);

--- a/pallets/capacity/src/tests/mock.rs
+++ b/pallets/capacity/src/tests/mock.rs
@@ -152,7 +152,7 @@ impl ProviderBoostRewardsProvider<Test> for TestRewardsProvider {
 	}
 
 	fn staking_reward_totals(
-		account_id: Self::AccountId,
+		_account_id: Self::AccountId,
 	) -> Result<
 		BoundedVec<UnclaimedRewardInfo<Test>, <Test as Config>::ProviderBoostHistoryLimit>,
 		DispatchError,
@@ -197,7 +197,6 @@ impl pallet_capacity::Config for Test {
 	type MaxEpochLength = ConstU32<100>;
 	type EpochNumber = u32;
 	type CapacityPerToken = TestCapacityPerToken;
-	type RewardEra = TestRewardEra;
 	type EraLength = ConstU32<10>;
 	type ProviderBoostHistoryLimit = ConstU32<12>;
 	type RewardsProvider = Capacity;

--- a/pallets/capacity/src/tests/provider_boost_history_tests.rs
+++ b/pallets/capacity/src/tests/provider_boost_history_tests.rs
@@ -6,6 +6,7 @@ use crate::{
 	Config, ProviderBoostHistory,
 	StakingType::{MaximumCapacity, ProviderBoost},
 };
+use common_primitives::capacity::RewardEra;
 use frame_support::assert_ok;
 use sp_runtime::traits::{Get, Zero};
 
@@ -71,12 +72,12 @@ fn provider_boost_history_add_era_balance_adds_entries_and_deletes_old_if_full()
 	}
 	assert_eq!(pbh.count(), bound as usize);
 
-	let new_era: <Test as Config>::RewardEra = 99;
+	let new_era: RewardEra = 99;
 	pbh.add_era_balance(&new_era, &1000u64);
 	assert_eq!(pbh.count(), bound as usize);
 	assert!(pbh.get_entry_for_era(&new_era).is_some());
 
-	let first_era: <Test as Config>::RewardEra = 1;
+	let first_era: RewardEra = 1;
 	assert!(pbh.get_entry_for_era(&first_era).is_none());
 }
 

--- a/pallets/capacity/src/tests/provider_boost_tests.rs
+++ b/pallets/capacity/src/tests/provider_boost_tests.rs
@@ -27,7 +27,7 @@ fn provider_boost_works() {
 		let capacity_details = Capacity::get_capacity_for(target).unwrap();
 		assert_eq!(capacity_details.total_capacity_issued, capacity);
 
-		let events = staking_events();
+		let events = capacity_events();
 		assert_eq!(
 			events.first().unwrap(),
 			&Event::ProviderBoosted { account, target, amount, capacity }

--- a/pallets/capacity/src/tests/reward_pool_tests.rs
+++ b/pallets/capacity/src/tests/reward_pool_tests.rs
@@ -2,6 +2,7 @@ use crate::{
 	tests::{mock::*, testing_utils::set_era_and_reward_pool},
 	BalanceOf, Config, ProviderBoostRewardPools, RewardPoolHistoryChunk,
 };
+use common_primitives::capacity::RewardEra;
 use frame_support::{assert_ok, traits::Get};
 use std::ops::Add;
 
@@ -9,7 +10,7 @@ use std::ops::Add;
 // runtime.
 fn fill_reward_pool_history_chunk(
 	chunk_index: u32,
-	starting_era: <Test as Config>::RewardEra,
+	starting_era: RewardEra,
 	number_of_items: u32,
 	starting_total_stake: BalanceOf<Test>,
 ) {

--- a/pallets/capacity/src/tests/rewards_provider_tests.rs
+++ b/pallets/capacity/src/tests/rewards_provider_tests.rs
@@ -4,7 +4,6 @@ use crate::{
 	StakingType::*, UnclaimedRewardInfo,
 };
 use frame_support::{assert_ok, traits::Len};
-use frame_system::pallet_prelude::BlockNumberFor;
 
 use crate::tests::testing_utils::{
 	run_to_block, set_era_and_reward_pool, setup_provider, system_run_to_block,

--- a/pallets/capacity/src/tests/rewards_provider_tests.rs
+++ b/pallets/capacity/src/tests/rewards_provider_tests.rs
@@ -1,16 +1,16 @@
 use super::mock::*;
 use crate::{
-	Config, CurrentEraInfo, Error, ProviderBoostHistories, ProviderBoostHistory,
-	ProviderBoostRewardsProvider, RewardEraInfo, StakingDetails, StakingType::*,
-	UnclaimedRewardInfo,
+	Config, ProviderBoostHistories, ProviderBoostHistory, ProviderBoostRewardsProvider,
+	StakingType::*, UnclaimedRewardInfo,
 };
-use frame_support::{assert_err, assert_ok, traits::Len};
+use frame_support::{assert_ok, traits::Len};
+use frame_system::pallet_prelude::BlockNumberFor;
 
 use crate::tests::testing_utils::{
 	run_to_block, set_era_and_reward_pool, setup_provider, system_run_to_block,
 };
 use common_primitives::msa::MessageSourceId;
-use sp_core::{Get, H256};
+use sp_core::Get;
 
 // This tests Capacity implementation of the trait, but uses the mock's constants,
 // to ensure that it's correctly specified in the pallet.

--- a/pallets/capacity/src/tests/stake_and_deposit_tests.rs
+++ b/pallets/capacity/src/tests/stake_and_deposit_tests.rs
@@ -37,7 +37,7 @@ fn stake_works() {
 			capacity_details
 		);
 
-		let events = staking_events();
+		let events = capacity_events();
 		assert_eq!(events.first().unwrap(), &Event::Staked { account, target, amount, capacity });
 
 		assert_eq!(
@@ -101,7 +101,7 @@ fn stake_increase_stake_amount_works() {
 
 		// First Stake
 		assert_ok!(Capacity::stake(RuntimeOrigin::signed(account), target, initial_amount));
-		let events = staking_events();
+		let events = capacity_events();
 		assert_eq!(
 			events.first().unwrap(),
 			&Event::Staked { account, target, amount: initial_amount, capacity }
@@ -136,7 +136,7 @@ fn stake_increase_stake_amount_works() {
 		assert_eq!(Capacity::get_capacity_for(target).unwrap().total_capacity_issued, 15);
 		assert_eq!(Capacity::get_capacity_for(target).unwrap().last_replenished_epoch, 0);
 
-		let events = staking_events();
+		let events = capacity_events();
 		assert_eq!(
 			events.last().unwrap(),
 			&Event::Staked { account, target, amount: additional_amount, capacity }

--- a/pallets/capacity/src/tests/testing_utils.rs
+++ b/pallets/capacity/src/tests/testing_utils.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use common_primitives::msa::MessageSourceId;
 
-pub fn staking_events() -> Vec<Event<Test>> {
+pub fn capacity_events() -> Vec<Event<Test>> {
 	let result = System::events()
 		.into_iter()
 		.map(|r| r.event)

--- a/pallets/capacity/src/tests/unstaking_tests.rs
+++ b/pallets/capacity/src/tests/unstaking_tests.rs
@@ -73,7 +73,7 @@ fn unstake_happy_path() {
 			}
 		);
 
-		let events = staking_events();
+		let events = capacity_events();
 		assert_eq!(
 			events.last().unwrap(),
 			&Event::UnStaked {
@@ -285,7 +285,7 @@ fn unstake_when_not_staking_to_target_errors() {
 }
 
 #[test]
-fn unstake_provider_boosted_target_adjusts_reward_pool_total() {
+fn unstake_provider_boosted_target_in_same_era_adjusts_reward_pool_total() {
 	new_test_ext().execute_with(|| {
 		// two accounts staking to the same target
 		let account1 = 600;

--- a/pallets/capacity/src/tests/withdrawal_tests.rs
+++ b/pallets/capacity/src/tests/withdrawal_tests.rs
@@ -17,7 +17,7 @@ fn impl_withdraw_is_successful() {
 		);
 
 		assert_ok!(Capacity::deduct(target_msa_id, 5u32.into()));
-		let events = staking_events();
+		let events = capacity_events();
 
 		assert_eq!(
 			events.last().unwrap(),

--- a/pallets/frequency-tx-payment/src/tests/mock.rs
+++ b/pallets/frequency-tx-payment/src/tests/mock.rs
@@ -219,7 +219,6 @@ impl pallet_capacity::Config for Test {
 	type EpochNumber = u32;
 	type CapacityPerToken = TestCapacityPerToken;
 	type RuntimeFreezeReason = RuntimeFreezeReason;
-	type RewardEra = u32;
 	type EraLength = ConstU32<5>;
 	type ProviderBoostHistoryLimit = ConstU32<6>;
 	type RewardsProvider = Capacity;

--- a/runtime/common/src/constants.rs
+++ b/runtime/common/src/constants.rs
@@ -397,4 +397,9 @@ parameter_types! {
 	pub const CapacityPerToken: Perbill = Perbill::from_percent(2);
 	pub const CapacityRewardCap: Permill = Permill::from_parts(3_800);  // 0.38% or 0.0038 per RewardEra
 }
+pub type CapacityRewardEraLength =
+	ConstU32<{ prod_or_testnet_or_local!(14 * DAYS, 1 * HOURS, 50) }>;
+
+pub type CapacityChangeStakingTargetThawEras = ConstU32<5>;
+
 // -end- Capacity Pallet ---

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -308,9 +308,10 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	(pallet_schemas::migration::v4::MigrateToV4<Runtime>,
-     pallet_capacity::migration::provider_boost_init::ProviderBoostInit<Runtime>,
-    ),
+	(
+		pallet_schemas::migration::v4::MigrateToV4<Runtime>,
+		pallet_capacity::migration::provider_boost_init::ProviderBoostInit<Runtime>,
+	),
 >;
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
@@ -505,8 +506,7 @@ impl pallet_capacity::Config for Runtime {
 	type EpochNumber = u32;
 	type CapacityPerToken = CapacityPerToken;
 	type RuntimeFreezeReason = RuntimeFreezeReason;
-	type RewardEra = u32;
-	type EraLength = ConstU32<{ 14 * DAYS }>;
+	type EraLength = CapacityRewardEraLength;
 	type ProviderBoostHistoryLimit = ConstU32<30u32>;
 	type RewardsProvider = Capacity;
 	type MaxRetargetsPerRewardEra = ConstU32<16>;
@@ -700,7 +700,7 @@ impl pallet_democracy::Config for Runtime {
 	type EnactmentPeriod = EnactmentPeriod;
 	type RuntimeEvent = RuntimeEvent;
 	type FastTrackVotingPeriod = FastTrackVotingPeriod;
-	type InstantAllowed = frame_support::traits::ConstBool<true>;
+	type InstantAllowed = ConstBool<true>;
 	type LaunchPeriod = LaunchPeriod;
 	type MaxProposals = DemocracyMaxProposals;
 	type MaxVotes = DemocracyMaxVotes;


### PR DESCRIPTION
# Goal
The goal of this PR is primarily to pull RewardEra out of the Capacity Config and make it the same type everywhere.

Other changes in this PR that were incidental to this refactor
* I renamed staking_events in testing_utils, because it captures all the events from the pallet.
* I pulled out RewardEraLength into constants so it could be different for different environments.

Related to #1970 

# Discussion
Having RewardEra be a defined type in the Capacity Config is something that's not done anywhere else.  It was also complicating implementing list_uncliamed_rewards runtime api because of the generics.

RewardEra is now defined as a u32 in common_primitives::capacity. While this makes other things easier, it necessitated some changes to RetargetInfo and not just updating tests and references.