### PR TITLE
feat(runtime): add metadata signed-extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,9 +1289,9 @@ dependencies = [
  "apache-avro",
  "common-primitives",
  "jsonrpsee",
- "sp-api",
- "sp-io",
- "sp-runtime",
+ "sp-api 28.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "thiserror",
 ]
 
@@ -1306,8 +1306,8 @@ name = "common-primitives"
 version = "0.0.0"
 dependencies = [
  "enumflags2",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "impl-serde",
  "numtoa",
  "parity-scale-codec",
@@ -1315,10 +1315,10 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-api",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-api 28.0.0",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -1328,8 +1328,8 @@ version = "0.0.0"
 dependencies = [
  "common-primitives",
  "cumulus-primitives-core",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "pallet-balances",
  "pallet-collator-selection",
  "pallet-collective",
@@ -1347,10 +1347,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "smallvec",
- "sp-core",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
- "sp-weights",
+ "sp-weights 29.0.0",
 ]
 
 [[package]]
@@ -1700,8 +1700,8 @@ dependencies = [
  "sc-client-api",
  "sc-service",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "url",
 ]
 
@@ -1722,10 +1722,10 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-consensus",
- "sp-core",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "tracing",
 ]
 
@@ -1756,17 +1756,17 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "schnellru",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 28.0.0",
+ "sp-application-crypto 32.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
- "sp-core",
- "sp-inherents",
- "sp-keystore",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 30.0.0",
+ "sp-inherents 28.0.0",
+ "sp-keystore 0.36.0",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
  "sp-timestamp",
  "substrate-prometheus-endpoint",
  "tracing",
@@ -1794,10 +1794,10 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-core",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "sp-timestamp",
- "sp-trie",
+ "sp-trie 31.0.0",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -1812,9 +1812,9 @@ dependencies = [
  "async-trait",
  "cumulus-primitives-parachain-inherent",
  "sp-consensus",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 28.0.0",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
  "thiserror",
 ]
 
@@ -1836,9 +1836,9 @@ dependencies = [
  "sc-client-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
  "tracing",
 ]
 
@@ -1856,14 +1856,14 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "scale-info",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-crypto-hashing",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-inherents 28.0.0",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
  "sp-std",
  "sp-storage",
- "sp-trie",
+ "sp-trie 31.0.0",
  "tracing",
 ]
 
@@ -1887,8 +1887,8 @@ dependencies = [
  "sc-client-api",
  "sc-consensus",
  "sp-consensus",
- "sp-maybe-compressed-blob 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime",
+ "sp-maybe-compressed-blob",
+ "sp-runtime 33.0.0",
  "tracing",
 ]
 
@@ -1921,11 +1921,11 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-utils",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "sp-transaction-pool",
 ]
 
@@ -1936,15 +1936,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8c0f09547fdc04119cf10f7c7fef2365e50c4ebb994501ff49c59b4513d860"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "pallet-aura",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 32.0.0",
  "sp-consensus-aura",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -1961,8 +1961,8 @@ dependencies = [
  "cumulus-primitives-proof-size-hostfunction",
  "environmental",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "impl-trait-for-tuples",
  "log",
  "pallet-message-queue",
@@ -1971,15 +1971,15 @@ dependencies = [
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
  "scale-info",
- "sp-core",
- "sp-externalities",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 30.0.0",
+ "sp-externalities 0.27.0",
+ "sp-inherents 28.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
  "sp-std",
- "sp-trie",
- "sp-version",
+ "sp-trie 31.0.0",
+ "sp-version 31.0.0",
  "staging-xcm",
  "trie-db",
 ]
@@ -2003,11 +2003,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07d60332d340bbf286af82553bd497bc958985b883c7e71a2cbb46ac8e814adb"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "pallet-session",
  "parity-scale-codec",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -2020,9 +2020,9 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-primitives",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-consensus-aura",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -2037,10 +2037,10 @@ dependencies = [
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "scale-info",
- "sp-api",
- "sp-runtime",
+ "sp-api 28.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
- "sp-trie",
+ "sp-trie 31.0.0",
  "staging-xcm",
 ]
 
@@ -2054,10 +2054,10 @@ dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-inherents",
+ "sp-core 30.0.0",
+ "sp-inherents 28.0.0",
  "sp-std",
- "sp-trie",
+ "sp-trie 31.0.0",
 ]
 
 [[package]]
@@ -2066,9 +2066,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7034e98f0883e9f5601063c7d252406ee5cc9c98090635e33fa3070bfcb62cb"
 dependencies = [
- "sp-externalities",
- "sp-runtime-interface",
- "sp-trie",
+ "sp-externalities 0.27.0",
+ "sp-runtime-interface 26.0.0",
+ "sp-trie 31.0.0",
 ]
 
 [[package]]
@@ -2080,7 +2080,7 @@ dependencies = [
  "cumulus-primitives-core",
  "futures",
  "parity-scale-codec",
- "sp-inherents",
+ "sp-inherents 28.0.0",
  "sp-std",
  "sp-timestamp",
 ]
@@ -2103,11 +2103,11 @@ dependencies = [
  "sc-sysinfo",
  "sc-telemetry",
  "sc-tracing",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-consensus",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
 ]
 
 [[package]]
@@ -2123,9 +2123,9 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-overseer",
  "sc-client-api",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
- "sp-state-machine",
+ "sp-state-machine 0.37.0",
  "thiserror",
 ]
 
@@ -2161,11 +2161,11 @@ dependencies = [
  "sc-service",
  "sc-tracing",
  "sc-utils",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "substrate-prometheus-endpoint",
  "tokio",
  "tracing",
@@ -2196,14 +2196,14 @@ dependencies = [
  "serde_json",
  "smoldot",
  "smoldot-light",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-authority-discovery",
  "sp-consensus-babe",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
  "sp-storage",
- "sp-version",
+ "sp-version 31.0.0",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2220,10 +2220,10 @@ dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
  "sp-std",
- "sp-trie",
+ "sp-trie 31.0.0",
 ]
 
 [[package]]
@@ -3059,21 +3059,21 @@ version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34134abd64876c2cba150b703d8c74b1b222147e61dbc33cbb9db72f7c1cdb2f"
 dependencies = [
- "frame-support",
- "frame-support-procedural",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-support-procedural 25.0.0",
+ "frame-system 30.0.0",
  "linregress",
  "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-runtime-interface",
+ "sp-api 28.0.0",
+ "sp-application-crypto 32.0.0",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
+ "sp-runtime-interface 26.0.0",
  "sp-std",
  "sp-storage",
  "static_assertions",
@@ -3091,8 +3091,8 @@ dependencies = [
  "clap",
  "comfy-table",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "gethostname",
  "handlebars",
  "itertools 0.10.5",
@@ -3106,23 +3106,23 @@ dependencies = [
  "sc-cli",
  "sc-client-api",
  "sc-client-db",
- "sc-executor",
+ "sc-executor 0.34.0",
  "sc-service",
  "sc-sysinfo",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-database",
- "sp-externalities",
- "sp-inherents",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
- "sp-state-machine",
+ "sp-externalities 0.27.0",
+ "sp-inherents 28.0.0",
+ "sp-io 32.0.0",
+ "sp-keystore 0.36.0",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
  "sp-storage",
- "sp-trie",
+ "sp-trie 31.0.0",
  "sp-wasm-interface",
  "thiserror",
  "thousands",
@@ -3147,14 +3147,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53ff3c76750b481f9fd633ccddeed955426adc28aee566dd7233b7ac22cda9f5"
 dependencies = [
  "frame-election-provider-solution-type",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic",
- "sp-core",
+ "sp-arithmetic 25.0.0",
+ "sp-core 30.0.0",
  "sp-npos-elections",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -3164,15 +3164,15 @@ version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d4542ef9abae48cb665f9992ece20ecded914ecfdaafb3f76968c645358b8df"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "frame-try-runtime",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
  "sp-tracing",
 ]
@@ -3190,6 +3190,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-metadata-hash-extension"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb1eec9eb46d3e016c95b2fa875118c04609f2150013c56a894cae00581e265"
+dependencies = [
+ "array-bytes 6.2.3",
+ "docify",
+ "frame-support 29.0.2",
+ "frame-system 29.0.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 32.0.0",
+]
+
+[[package]]
 name = "frame-remote-externalities"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3201,15 +3217,57 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "serde",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-crypto-hashing",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
  "spinners",
  "substrate-rpc-client",
  "tokio",
  "tokio-retry",
+]
+
+[[package]]
+name = "frame-support"
+version = "29.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e52c84b611d2049d9253f83a62ab0f093e4be5c42a7ef42ea5bb16d6611e32"
+dependencies = [
+ "aquamarine",
+ "array-bytes 6.2.3",
+ "bitflags 1.3.2",
+ "docify",
+ "environmental",
+ "frame-metadata",
+ "frame-support-procedural 24.0.0",
+ "impl-trait-for-tuples",
+ "k256",
+ "log",
+ "macro_magic",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "sp-api 27.0.1",
+ "sp-arithmetic 24.0.0",
+ "sp-core 29.0.0",
+ "sp-crypto-hashing-proc-macro",
+ "sp-debug-derive",
+ "sp-genesis-builder 0.8.0",
+ "sp-inherents 27.0.0",
+ "sp-io 31.0.0",
+ "sp-metadata-ir",
+ "sp-runtime 32.0.0",
+ "sp-staking 27.0.0",
+ "sp-state-machine 0.36.0",
+ "sp-std",
+ "sp-tracing",
+ "sp-weights 28.0.0",
+ "static_assertions",
+ "tt-call",
 ]
 
 [[package]]
@@ -3224,7 +3282,7 @@ dependencies = [
  "docify",
  "environmental",
  "frame-metadata",
- "frame-support-procedural",
+ "frame-support-procedural 25.0.0",
  "impl-trait-for-tuples",
  "k256",
  "log",
@@ -3235,23 +3293,43 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-api",
- "sp-arithmetic",
- "sp-core",
+ "sp-api 28.0.0",
+ "sp-arithmetic 25.0.0",
+ "sp-core 30.0.0",
  "sp-crypto-hashing-proc-macro",
  "sp-debug-derive",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
+ "sp-genesis-builder 0.9.0",
+ "sp-inherents 28.0.0",
+ "sp-io 32.0.0",
  "sp-metadata-ir",
- "sp-runtime",
- "sp-staking",
- "sp-state-machine",
+ "sp-runtime 33.0.0",
+ "sp-staking 28.0.0",
+ "sp-state-machine 0.37.0",
  "sp-std",
  "sp-tracing",
- "sp-weights",
+ "sp-weights 29.0.0",
  "static_assertions",
  "tt-call",
+]
+
+[[package]]
+name = "frame-support-procedural"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf1d648c4007d421b9677b3c893256913498fff159dc2d85022cdd9cc432f3c"
+dependencies = [
+ "Inflector",
+ "cfg-expr",
+ "derive-syn-parse 0.1.5",
+ "expander 2.2.1",
+ "frame-support-procedural-tools 10.0.0",
+ "itertools 0.10.5",
+ "macro_magic",
+ "proc-macro-warning",
+ "proc-macro2",
+ "quote",
+ "sp-crypto-hashing",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3264,7 +3342,7 @@ dependencies = [
  "cfg-expr",
  "derive-syn-parse 0.1.5",
  "expander 2.2.1",
- "frame-support-procedural-tools",
+ "frame-support-procedural-tools 11.0.1",
  "itertools 0.10.5",
  "macro_magic",
  "proc-macro-warning",
@@ -3276,12 +3354,36 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3363df38464c47a73eb521a4f648bfcc7537a82d70347ef8af3f73b6d019e910"
+dependencies = [
+ "frame-support-procedural-tools-derive 11.0.0",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "frame-support-procedural-tools"
 version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b482a1d18fa63aed1ff3fe3fcfb3bc23d92cb3903d6b9774f75dc2c4e1001c3a"
 dependencies = [
- "frame-support-procedural-tools-derive",
+ "frame-support-procedural-tools-derive 12.0.0",
  "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "frame-support-procedural-tools-derive"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68672b9ec6fe72d259d3879dc212c5e42e977588cdac830c76f54d9f492aeb58"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -3300,23 +3402,44 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bc20a793c3cec0b11165c1075fe11a255b2491f3eef8230bb3073cb296e7383"
+dependencies = [
+ "cfg-if",
+ "docify",
+ "frame-support 29.0.2",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-runtime 32.0.0",
+ "sp-std",
+ "sp-version 30.0.0",
+ "sp-weights 28.0.0",
+]
+
+[[package]]
+name = "frame-system"
 version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c302f711acf3196b4bf2b4629a07a2ac6e44cd1782434ec88b85d59adfb1204d"
 dependencies = [
  "cfg-if",
  "docify",
- "frame-support",
+ "frame-support 30.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
- "sp-version",
- "sp-weights",
+ "sp-version 31.0.0",
+ "sp-weights 29.0.0",
 ]
 
 [[package]]
@@ -3326,12 +3449,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e41213421daaf14370e6d59016bd1be5e8d8c990bb336b72e72b3c60d874d3df"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -3342,7 +3465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b48b28339a07bb7e797d3546c29600dd0b7c97ffd9d6642665dc96d81c0b475"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
+ "sp-api 28.0.0",
 ]
 
 [[package]]
@@ -3351,10 +3474,10 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be404b49a2c947a77ec813b372ca5119182f8de131ee98a5656bc1043958b8b"
 dependencies = [
- "frame-support",
+ "frame-support 30.0.0",
  "parity-scale-codec",
- "sp-api",
- "sp-runtime",
+ "sp-api 28.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -3382,8 +3505,8 @@ dependencies = [
  "derive_more",
  "frame-benchmarking",
  "frame-benchmarking-cli",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "frequency-runtime",
  "frequency-service",
  "futures",
@@ -3400,19 +3523,19 @@ dependencies = [
  "polkadot-service",
  "sc-cli",
  "sc-client-api",
- "sc-executor",
+ "sc-executor 0.34.0",
  "sc-service",
  "sc-sysinfo",
  "sc-telemetry",
  "sc-tracing",
  "serde",
  "serde_json",
- "sp-api",
- "sp-core",
- "sp-inherents",
- "sp-io",
+ "sp-api 28.0.0",
+ "sp-core 30.0.0",
+ "sp-inherents 28.0.0",
+ "sp-io 32.0.0",
  "sp-keyring",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-timestamp",
  "substrate-build-script-utils",
  "try-runtime-cli",
@@ -3432,8 +3555,9 @@ dependencies = [
  "cumulus-primitives-timestamp",
  "frame-benchmarking",
  "frame-executive",
- "frame-support",
- "frame-system",
+ "frame-metadata-hash-extension",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -3477,21 +3601,21 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-block-builder",
  "sp-consensus-aura",
- "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
+ "sp-core 30.0.0",
+ "sp-genesis-builder 0.9.0",
+ "sp-inherents 28.0.0",
+ "sp-io 32.0.0",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-session",
  "sp-std",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 31.0.0",
  "staging-parachain-info",
- "substrate-wasm-builder 17.0.0",
+ "substrate-wasm-builder 18.0.1",
  "system-runtime-api",
 ]
 
@@ -3519,7 +3643,7 @@ dependencies = [
  "derive_more",
  "frame-benchmarking",
  "frame-benchmarking-cli",
- "frame-system",
+ "frame-system 30.0.0",
  "frequency-runtime",
  "futures",
  "hex",
@@ -3550,7 +3674,7 @@ dependencies = [
  "sc-client-db",
  "sc-consensus",
  "sc-consensus-manual-seal",
- "sc-executor",
+ "sc-executor 0.34.0",
  "sc-keystore",
  "sc-network",
  "sc-network-common",
@@ -3566,16 +3690,16 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
- "sp-core",
- "sp-inherents",
- "sp-keystore",
+ "sp-core 30.0.0",
+ "sp-inherents 28.0.0",
+ "sp-keystore 0.36.0",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-session",
  "sp-timestamp",
  "sp-transaction-pool",
@@ -5504,6 +5628,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "merkleized-metadata"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f313fcff1d2a4bcaa2deeaa00bf7530d77d5f7bd0467a117dde2e29a75a7a17a"
+dependencies = [
+ "array-bytes 6.2.3",
+ "blake3",
+ "frame-metadata",
+ "parity-scale-codec",
+ "scale-decode",
+ "scale-info",
+]
+
+[[package]]
 name = "merlin"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5588,13 +5726,13 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "sc-offchain",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-beefy",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 33.0.0",
 ]
 
 [[package]]
@@ -5606,11 +5744,11 @@ dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
  "serde",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 33.0.0",
 ]
 
 [[package]]
@@ -6188,12 +6326,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "561cfeb28ce89a79f4e1663a44724a1f551536bd41c1d2c6e66432480f948f68"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6203,15 +6341,15 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b1085f847e49c5a56d4a7f87815f4ac6d37cd7e3997e2444abc105e2207aeca"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 32.0.0",
  "sp-consensus-aura",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6221,14 +6359,14 @@ version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "485ca0e15ffc8c60d8e101112f3ce26fe139582f7416e2697955b63f478cf038"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 32.0.0",
  "sp-authority-discovery",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6238,12 +6376,12 @@ version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa1f02863403c1cf5e9f49fd492c8cdb329d4b45029f3f19f278b3ba832a2b81"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6254,21 +6392,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91a0fdb62c2d72c3c680deca50121d4bf2d8ed4b24dedd85f5b98ac454e781b"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-authorship",
  "pallet-session",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 32.0.0",
  "sp-consensus-babe",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 28.0.0",
  "sp-std",
 ]
 
@@ -6282,15 +6420,15 @@ dependencies = [
  "docify",
  "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
  "sp-tracing",
 ]
@@ -6303,12 +6441,12 @@ checksum = "f68b79a1f9f10c63377177155a4ac3ac08db356027a3d8bc826e1af65c885b8d"
 dependencies = [
  "docify",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6318,8 +6456,8 @@ version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f32bf6b3fec18e3ad0831e98e39857e2be1a8c3c240b978930f98f6df82cfa7"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-authorship",
  "pallet-session",
@@ -6327,9 +6465,9 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-consensus-beefy",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 28.0.0",
  "sp-std",
 ]
 
@@ -6341,8 +6479,8 @@ checksum = "c960ba2f8be1e52f238ccf2e7bffb5b96adf8d15fb19ac24ac01571c4b61954a"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-beefy",
  "pallet-mmr",
@@ -6350,12 +6488,12 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-consensus-beefy",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
  "sp-std",
 ]
 
@@ -6366,15 +6504,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abeb09ea0290befa44738288c5dfe72ed9b21ec5e3c5d7e82e081376f1c029be"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6386,13 +6524,13 @@ checksum = "16828306edf66de7412d769f4716fd54f9046713e8e63a774f75814c9ca7a898"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-runtime",
+ "sp-arithmetic 25.0.0",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6403,16 +6541,16 @@ dependencies = [
  "common-primitives",
  "common-runtime",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-balances",
  "pallet-msa",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6423,16 +6561,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d309cc33a3cc3485527faf3429e2f776dd64311d031d330d079444231f85c5c4"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-bounties",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6443,8 +6581,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf453482e8f6d7d6534f982a02d1b61b1997c561d541cdb67477cd6b66636fcf"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-authorship",
  "pallet-balances",
@@ -6452,8 +6590,8 @@ dependencies = [
  "parity-scale-codec",
  "rand",
  "scale-info",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 33.0.0",
+ "sp-staking 28.0.0",
  "sp-std",
 ]
 
@@ -6464,14 +6602,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3241a9f6ba5fde426bc306ae514550377f3407dcfcc351d47e9fff297ccde6a0"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6483,13 +6621,13 @@ checksum = "bb246d7cb84a78d1847770cf7c76e52d8b85dc80e8b6cd34414f9cbae0f5511f"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io",
- "sp-runtime",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6500,15 +6638,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "247fc95fd76eff387678b251f56ea6832df0dcd55269cd76fe1b8a9fa888d0f4"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6520,18 +6658,18 @@ checksum = "ea7ebcb00352d6a814f3f92ed702a898eb4d78edba740930f97b6a38e577f820"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-election-provider-support-benchmarking",
  "parity-scale-codec",
  "rand",
  "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
+ "sp-arithmetic 25.0.0",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
  "sp-npos-elections",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
  "strum 0.24.1",
 ]
@@ -6544,10 +6682,10 @@ checksum = "9c57509f5a4fd41a953c2e29813a2ba09f30a5bf59c5f98bfcbb7c2619b7d931"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
- "frame-system",
+ "frame-system 30.0.0",
  "parity-scale-codec",
  "sp-npos-elections",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6558,16 +6696,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4cdc5615ff4651a9e85f980781b0023fff25572130006cd73bf287b7c160b3"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
  "sp-npos-elections",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 33.0.0",
+ "sp-staking 28.0.0",
  "sp-std",
 ]
 
@@ -6580,14 +6718,14 @@ dependencies = [
  "docify",
  "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
+ "sp-staking 28.0.0",
  "sp-std",
 ]
 
@@ -6598,8 +6736,8 @@ dependencies = [
  "common-primitives",
  "common-runtime",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-balances",
  "pallet-capacity",
@@ -6608,9 +6746,9 @@ dependencies = [
  "pallet-utility",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6625,13 +6763,13 @@ dependencies = [
  "parity-scale-codec",
  "rayon",
  "sc-client-api",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
- "sp-weights",
+ "sp-weights 29.0.0",
  "tokio",
 ]
 
@@ -6640,10 +6778,10 @@ name = "pallet-frequency-tx-payment-runtime-api"
 version = "0.0.0"
 dependencies = [
  "common-primitives",
- "frame-support",
+ "frame-support 30.0.0",
  "pallet-transaction-payment",
  "parity-scale-codec",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-std",
 ]
 
@@ -6654,20 +6792,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b22d7b2ad0fa9811c441051cc90792924d58fe6d0cfeff8db231da68fcc9fa"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 32.0.0",
  "sp-consensus-grandpa",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 28.0.0",
  "sp-std",
 ]
 
@@ -6679,8 +6817,8 @@ dependencies = [
  "common-runtime",
  "env_logger",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "handles-utils",
  "log",
  "numtoa",
@@ -6688,10 +6826,10 @@ dependencies = [
  "pretty_assertions",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-keystore 0.36.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6701,14 +6839,14 @@ version = "0.0.0"
 dependencies = [
  "common-helpers",
  "common-primitives",
- "frame-support",
+ "frame-support 30.0.0",
  "jsonrpsee",
  "pallet-handles-runtime-api",
  "rayon",
  "sc-client-api",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
  "tokio",
 ]
@@ -6718,7 +6856,7 @@ name = "pallet-handles-runtime-api"
 version = "0.0.0"
 dependencies = [
  "common-primitives",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-std",
 ]
 
@@ -6730,13 +6868,13 @@ checksum = "04f0a43b8d840ffd170fa05e277160dedfafa10c83cb39089afcce571fed5e08"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6747,17 +6885,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57205599c150041e666cbdb53300201de5378b603f12d1efcf7dfa8d61fd8829"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-authorship",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-application-crypto 32.0.0",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
+ "sp-staking 28.0.0",
  "sp-std",
 ]
 
@@ -6768,14 +6906,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b5330b6bed6d82e0aa9ae18af0f8ce1f79cf86cf7cb49efc38920a652ad948"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
  "sp-keyring",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6786,14 +6924,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db551d8d3fec5f7b584db0b28af396412e25bb0ae0e018c3cb75761efc71115c"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6805,17 +6943,17 @@ checksum = "31856e2c797c6a262c22b63ce195901ef48b66d7b80a8a1d0f3b5f1c88a51332"
 dependencies = [
  "environmental",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-arithmetic 25.0.0",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
- "sp-weights",
+ "sp-weights 29.0.0",
 ]
 
 [[package]]
@@ -6826,8 +6964,8 @@ dependencies = [
  "common-primitives",
  "common-runtime",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "multibase",
  "parity-scale-codec",
@@ -6836,9 +6974,9 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6848,13 +6986,13 @@ version = "0.0.0"
 dependencies = [
  "common-helpers",
  "common-primitives",
- "frame-support",
+ "frame-support 30.0.0",
  "jsonrpsee",
  "pallet-messages-runtime-api",
  "sc-client-api",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "tokio",
 ]
 
@@ -6863,8 +7001,8 @@ name = "pallet-messages-runtime-api"
 version = "0.0.0"
 dependencies = [
  "common-primitives",
- "frame-support",
- "sp-api",
+ "frame-support 30.0.0",
+ "sp-api 28.0.0",
  "sp-std",
 ]
 
@@ -6875,15 +7013,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "992df88910f526671b357d9269a5c7d6c8ab025ee7126fce897d2869e2059390"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6894,8 +7032,8 @@ dependencies = [
  "common-primitives",
  "common-runtime",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "hex",
  "log",
  "pallet-collective",
@@ -6907,13 +7045,13 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-core",
- "sp-io",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
  "sp-keyring",
- "sp-keystore",
- "sp-runtime",
+ "sp-keystore 0.36.0",
+ "sp-runtime 33.0.0",
  "sp-std",
- "sp-weights",
+ "sp-weights 29.0.0",
 ]
 
 [[package]]
@@ -6928,11 +7066,11 @@ dependencies = [
  "parking_lot 0.12.3",
  "rayon",
  "sc-client-api",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
  "tokio",
 ]
@@ -6942,9 +7080,9 @@ name = "pallet-msa-runtime-api"
 version = "0.0.0"
 dependencies = [
  "common-primitives",
- "frame-support",
+ "frame-support 30.0.0",
  "parity-scale-codec",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-std",
 ]
 
@@ -6955,13 +7093,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e06afee42c1b10c172500e3c455543ecaae7c7f3aa9631e23a66d82547f6108"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6972,13 +7110,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71526b32ab454e10db38f35aff90ed5d537962597e1aa9cc9211c8020e566e85"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-runtime",
+ "sp-arithmetic 25.0.0",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -6988,16 +7126,16 @@ version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f327bb93b56ce995d95eaf05b1bfc6b23a453b9412aa41ff6d362dff722413c"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
+ "sp-staking 28.0.0",
  "sp-std",
  "sp-tracing",
 ]
@@ -7010,16 +7148,16 @@ checksum = "1f4c7bb170227cbbfcc8d1795cb0e2053c79a1d2738c5f85b13afee151e2d334"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "pallet-bags-list",
  "pallet-nomination-pools",
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
- "sp-runtime-interface",
- "sp-staking",
+ "sp-runtime 33.0.0",
+ "sp-runtime-interface 26.0.0",
+ "sp-staking 28.0.0",
  "sp-std",
 ]
 
@@ -7031,7 +7169,7 @@ checksum = "4eb2bb3ab695ec7e79a668823bfa63329fd087f02ce707316f8f33fe7c5577e6"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-std",
 ]
 
@@ -7041,15 +7179,15 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e2f06e9da4dff8765a4bbae81b06932ff6ab8f0197d26497a5edd2b58efa303"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 33.0.0",
+ "sp-staking 28.0.0",
  "sp-std",
 ]
 
@@ -7061,8 +7199,8 @@ checksum = "812bc221afa5d12ff341455a1d62a2516e734af84324433392c8b2923d89d80b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-babe",
  "pallet-balances",
@@ -7073,8 +7211,8 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
- "sp-staking",
+ "sp-runtime 33.0.0",
+ "sp-staking 28.0.0",
  "sp-std",
 ]
 
@@ -7086,8 +7224,8 @@ dependencies = [
  "common-primitives",
  "common-runtime",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "p256",
  "pallet-balances",
@@ -7095,11 +7233,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
- "sp-core",
- "sp-io",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
  "sp-keyring",
- "sp-keystore",
- "sp-runtime",
+ "sp-keystore 0.36.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -7110,14 +7248,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8573ce5aad3f488b2565707624c675c25af8b67d6ece102565d9fdbf57eaed8"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -7128,12 +7266,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d6b9f7210b6cd4dcf531c1f8729eaeb7dfbed8e8b1b01b1747240b0f8a715d"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -7144,16 +7282,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e06d19491f9a6a0cde4ba3e6c02d8366af60efea8fbf9ffb27ca674b1ecca622"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-arithmetic 25.0.0",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -7164,12 +7302,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786d77701ccba3306b0c4bf8a2c3d2f160723eb219db7e2248cf505e5cdb86f6"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -7181,15 +7319,15 @@ checksum = "6866372ff2428967876e906c725b97a4b32612c9a2a9d9c3c1478c7060ea5ff6"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic",
- "sp-io",
- "sp-runtime",
+ "sp-arithmetic 25.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -7199,13 +7337,13 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eec41db5afabcc945d98ce427980faa56a867bdcd40133e662cf96546ff951de"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -7217,15 +7355,15 @@ checksum = "5daf9f2a35fb6902011fc66e0d8c9831acd86512a78f298b52aba4970b121075"
 dependencies = [
  "docify",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
- "sp-weights",
+ "sp-weights 29.0.0",
 ]
 
 [[package]]
@@ -7235,8 +7373,8 @@ dependencies = [
  "common-primitives",
  "common-runtime",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "numtoa",
  "pallet-collective",
@@ -7246,12 +7384,12 @@ dependencies = [
  "serde_json",
  "serial_test",
  "smallvec",
- "sp-core",
- "sp-io",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
  "sp-keyring",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
- "sp-weights",
+ "sp-weights 29.0.0",
 ]
 
 [[package]]
@@ -7260,15 +7398,15 @@ version = "0.0.0"
 dependencies = [
  "common-helpers",
  "common-primitives",
- "frame-support",
+ "frame-support 30.0.0",
  "jsonrpsee",
  "pallet-schemas-runtime-api",
  "sc-client-api",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
  "tokio",
 ]
@@ -7278,9 +7416,9 @@ name = "pallet-schemas-runtime-api"
 version = "0.0.0"
 dependencies = [
  "common-primitives",
- "frame-support",
- "sp-api",
- "sp-runtime",
+ "frame-support 30.0.0",
+ "sp-api 28.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -7290,21 +7428,21 @@ version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42218759d10405996ae378968751a9b1142b47f6b887562f2df50cc14b1c7eaa"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "impl-trait-for-tuples",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-session",
- "sp-staking",
- "sp-state-machine",
+ "sp-staking 28.0.0",
+ "sp-state-machine 0.37.0",
  "sp-std",
- "sp-trie",
+ "sp-trie 31.0.0",
 ]
 
 [[package]]
@@ -7314,13 +7452,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aafe03e451af13c599da6f2cca66e20a5c0b522b31ad7c35d6a1a261081a2f70"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "pallet-session",
  "pallet-staking",
  "parity-scale-codec",
  "rand",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-session",
  "sp-std",
 ]
@@ -7332,15 +7470,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ce9f43cb5d254f17a3f747b5aa4ecfaace31d765bd102a4b4b2565b8353c3a"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "parity-scale-codec",
  "rand_chacha 0.2.2",
  "scale-info",
- "sp-arithmetic",
- "sp-io",
- "sp-runtime",
+ "sp-arithmetic 25.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -7352,8 +7490,8 @@ checksum = "0eb21ca0ce32bc5dc5df451001bff611e8cf530b8606f9b5705e4a428c6fa0cf"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-authorship",
  "pallet-session",
@@ -7361,10 +7499,10 @@ dependencies = [
  "rand_chacha 0.2.2",
  "scale-info",
  "serde",
- "sp-application-crypto",
- "sp-io",
- "sp-runtime",
- "sp-staking",
+ "sp-application-crypto 32.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
+ "sp-staking 28.0.0",
  "sp-std",
 ]
 
@@ -7387,7 +7525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e341c47481040b68edcf166ad34633c4c5da20d1559413e68387da935a6ae18"
 dependencies = [
  "log",
- "sp-arithmetic",
+ "sp-arithmetic 25.0.0",
 ]
 
 [[package]]
@@ -7397,8 +7535,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2773af1f9c4c4d70ec9a0a4feed15ac47355544aee9520c2901d751eef644cef"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
- "sp-staking",
+ "sp-api 28.0.0",
+ "sp-staking 28.0.0",
 ]
 
 [[package]]
@@ -7408,14 +7546,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99e81be14eff1fa562bb0b9af69932e91803d9e5c63888ad9c390741a7906058"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -7427,16 +7565,16 @@ dependencies = [
  "common-runtime",
  "env_logger",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "parity-scale-codec",
  "pretty_assertions",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-keystore 0.36.0",
+ "sp-runtime 33.0.0",
  "sp-std",
  "twox-hash",
 ]
@@ -7447,15 +7585,15 @@ version = "0.0.0"
 dependencies = [
  "common-helpers",
  "common-primitives",
- "frame-support",
+ "frame-support 30.0.0",
  "jsonrpsee",
  "pallet-stateful-storage-runtime-api",
  "sc-client-api",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
  "tokio",
 ]
@@ -7465,9 +7603,9 @@ name = "pallet-stateful-storage-runtime-api"
 version = "0.0.0"
 dependencies = [
  "common-primitives",
- "frame-support",
- "sp-api",
- "sp-runtime",
+ "frame-support 30.0.0",
+ "sp-api 28.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -7479,12 +7617,12 @@ checksum = "78e1b72aeabc9f0ba731229ccef31d8e5a160faae5edf2651a8cdacaa2690124"
 dependencies = [
  "docify",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -7496,15 +7634,15 @@ dependencies = [
  "common-primitives",
  "common-runtime",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -7516,14 +7654,14 @@ checksum = "c307589adc04a0d578ae00231bc04f1a53ef07a0aa2f3e9d4c7e4bf419bf6e3d"
 dependencies = [
  "docify",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
+ "sp-inherents 28.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
  "sp-storage",
  "sp-timestamp",
@@ -7536,16 +7674,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efa45c34750ebd677c4d449695e84cc25c1ce5b9eea531332d1c60e22b69ff01"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -7555,14 +7693,14 @@ version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d598d0ad779d19fa44ce6f80c57192537fa9f84995953bf2a8c104b7676b6b7"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -7575,12 +7713,12 @@ dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-rpc",
- "sp-runtime",
- "sp-weights",
+ "sp-runtime 33.0.0",
+ "sp-weights 29.0.0",
 ]
 
 [[package]]
@@ -7591,9 +7729,9 @@ checksum = "4d34487aec13e174906b6bba112f672e72948d16b8ee0752b8bebd659ac528dc"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
- "sp-api",
- "sp-runtime",
- "sp-weights",
+ "sp-api 28.0.0",
+ "sp-runtime 33.0.0",
+ "sp-weights 29.0.0",
 ]
 
 [[package]]
@@ -7604,15 +7742,15 @@ checksum = "317d231ff8a773e94fe5be8d3710213215208e7993bfeedd96bd6f4402da114a"
 dependencies = [
  "docify",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "impl-trait-for-tuples",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -7623,13 +7761,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79b879fb8c20405663309986621856050efc31969c2d2a209d78373356a62e27"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -7640,12 +7778,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391edd70faa651c43c2bbd03fcb5cd3f0be8b45ed38231991fe46d33a4cc4ef5"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -7656,12 +7794,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92b496a76f13982cd754be92c9167d71acad169d101db197910e2a6e94f49997"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-runtime",
+ "sp-api 28.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -7673,16 +7811,16 @@ checksum = "f5d45837646e1468bd766dc8f9006a0bd3a59410004134d7f2bb63aee3d63fa0"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
@@ -7696,13 +7834,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "287ba50bd51c3c923fd35aa8e25f778092c7f3027d583389688bc003b24897c4"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io",
- "sp-runtime",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
@@ -8092,8 +8230,8 @@ dependencies = [
  "polkadot-primitives",
  "rand",
  "schnellru",
- "sp-core",
- "sp-keystore",
+ "sp-core 30.0.0",
+ "sp-keystore 0.36.0",
  "thiserror",
  "tracing-gum",
 ]
@@ -8137,16 +8275,16 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-service",
  "sc-cli",
- "sc-executor",
+ "sc-executor 0.34.0",
  "sc-service",
  "sc-storage-monitor",
  "sc-sysinfo",
  "sc-tracing",
- "sp-core",
- "sp-io",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
  "sp-keyring",
- "sp-maybe-compressed-blob 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime",
+ "sp-maybe-compressed-blob",
+ "sp-runtime 33.0.0",
  "substrate-build-script-utils",
  "thiserror",
  "try-runtime-cli",
@@ -8167,9 +8305,9 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-keystore 0.36.0",
+ "sp-runtime 33.0.0",
  "thiserror",
  "tokio-util",
  "tracing-gum",
@@ -8183,8 +8321,8 @@ checksum = "89a881f63ab7a652aba19300f95f9341ee245ad45a3f89cf02053ecace474769"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -8208,8 +8346,8 @@ dependencies = [
  "polkadot-primitives",
  "sc-network",
  "schnellru",
- "sp-application-crypto",
- "sp-keystore",
+ "sp-application-crypto 32.0.0",
+ "sp-keystore 0.36.0",
  "thiserror",
  "tracing-gum",
 ]
@@ -8224,8 +8362,8 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-primitives",
  "reed-solomon-novelpoly",
- "sp-core",
- "sp-trie",
+ "sp-core 30.0.0",
+ "sp-trie 31.0.0",
  "thiserror",
 ]
 
@@ -8245,10 +8383,10 @@ dependencies = [
  "rand_chacha 0.3.1",
  "sc-network",
  "sc-network-common",
- "sp-application-crypto",
- "sp-core",
+ "sp-application-crypto 32.0.0",
+ "sp-core 30.0.0",
  "sp-crypto-hashing",
- "sp-keystore",
+ "sp-keystore 0.36.0",
  "tracing-gum",
 ]
 
@@ -8289,8 +8427,8 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "sp-core",
- "sp-maybe-compressed-blob 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core 30.0.0",
+ "sp-maybe-compressed-blob",
  "thiserror",
  "tracing-gum",
 ]
@@ -8321,10 +8459,10 @@ dependencies = [
  "sc-keystore",
  "schnellru",
  "schnorrkel 0.11.4",
- "sp-application-crypto",
+ "sp-application-crypto 32.0.0",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "thiserror",
  "tracing-gum",
 ]
@@ -8368,7 +8506,7 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-statement-table",
  "schnellru",
- "sp-keystore",
+ "sp-keystore 0.36.0",
  "thiserror",
  "tracing-gum",
 ]
@@ -8383,7 +8521,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "sp-keystore",
+ "sp-keystore 0.36.0",
  "thiserror",
  "tracing-gum",
  "wasm-timer",
@@ -8407,7 +8545,7 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
- "sp-maybe-compressed-blob 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-maybe-compressed-blob",
  "tracing-gum",
 ]
 
@@ -8477,7 +8615,7 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "sp-blockchain",
- "sp-inherents",
+ "sp-inherents 28.0.0",
  "thiserror",
  "tracing-gum",
 ]
@@ -8543,8 +8681,8 @@ dependencies = [
  "polkadot-primitives",
  "rand",
  "slotmap",
- "sp-core",
- "sp-maybe-compressed-blob 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core 30.0.0",
+ "sp-maybe-compressed-blob",
  "sp-wasm-interface",
  "tempfile",
  "thiserror",
@@ -8564,7 +8702,7 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
  "polkadot-primitives",
- "sp-keystore",
+ "sp-keystore 0.36.0",
  "thiserror",
  "tracing-gum",
 ]
@@ -8584,14 +8722,14 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
- "sc-executor",
- "sc-executor-common",
- "sc-executor-wasmtime",
+ "sc-executor 0.34.0",
+ "sc-executor-common 0.31.0",
+ "sc-executor-wasmtime 0.31.0",
  "seccompiler",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-crypto-hashing",
- "sp-externalities",
- "sp-io",
+ "sp-externalities 0.27.0",
+ "sp-io 32.0.0",
  "sp-tracing",
  "thiserror",
  "tracing-gum",
@@ -8627,7 +8765,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-primitives",
  "sc-network",
- "sp-core",
+ "sp-core 30.0.0",
  "thiserror",
  "tokio",
 ]
@@ -8691,12 +8829,12 @@ dependencies = [
  "polkadot-primitives",
  "schnorrkel 0.11.4",
  "serde",
- "sp-application-crypto",
+ "sp-application-crypto 32.0.0",
  "sp-consensus-babe",
- "sp-core",
- "sp-keystore",
- "sp-maybe-compressed-blob 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-keystore 0.36.0",
+ "sp-maybe-compressed-blob",
+ "sp-runtime 33.0.0",
  "thiserror",
  "zstd 0.12.4",
 ]
@@ -8732,11 +8870,11 @@ dependencies = [
  "sc-network",
  "sc-transaction-pool-api",
  "smallvec",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-authority-discovery",
  "sp-blockchain",
  "sp-consensus-babe",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -8770,9 +8908,9 @@ dependencies = [
  "rand",
  "sc-client-api",
  "schnellru",
- "sp-application-crypto",
- "sp-core",
- "sp-keystore",
+ "sp-application-crypto 32.0.0",
+ "sp-core 30.0.0",
+ "sp-keystore 0.36.0",
  "thiserror",
  "tracing-gum",
 ]
@@ -8794,8 +8932,8 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-primitives",
  "sc-client-api",
- "sp-api",
- "sp-core",
+ "sp-api 28.0.0",
+ "sp-core 30.0.0",
  "tikv-jemalloc-ctl",
  "tracing-gum",
 ]
@@ -8812,10 +8950,10 @@ dependencies = [
  "polkadot-core-primitives",
  "scale-info",
  "serde",
- "sp-core",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
- "sp-weights",
+ "sp-weights 29.0.0",
 ]
 
 [[package]]
@@ -8832,17 +8970,17 @@ dependencies = [
  "polkadot-parachain-primitives",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-arithmetic",
+ "sp-api 28.0.0",
+ "sp-application-crypto 32.0.0",
+ "sp-arithmetic 25.0.0",
  "sp-authority-discovery",
  "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
- "sp-staking",
+ "sp-core 30.0.0",
+ "sp-inherents 28.0.0",
+ "sp-io 32.0.0",
+ "sp-keystore 0.36.0",
+ "sp-runtime 33.0.0",
+ "sp-staking 28.0.0",
  "sp-std",
 ]
 
@@ -8869,13 +9007,13 @@ dependencies = [
  "sc-rpc-spec-v2",
  "sc-sync-state-rpc",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-keystore",
- "sp-runtime",
+ "sp-keystore 0.36.0",
+ "sp-runtime 33.0.0",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
 ]
@@ -8889,8 +9027,8 @@ dependencies = [
  "bitvec",
  "frame-benchmarking",
  "frame-election-provider-support",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "impl-trait-for-tuples",
  "libsecp256k1",
  "log",
@@ -8917,14 +9055,14 @@ dependencies = [
  "serde",
  "serde_derive",
  "slot-range-helper",
- "sp-api",
- "sp-core",
- "sp-inherents",
- "sp-io",
+ "sp-api 28.0.0",
+ "sp-core 30.0.0",
+ "sp-inherents 28.0.0",
+ "sp-io 32.0.0",
  "sp-npos-elections",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 28.0.0",
  "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
@@ -8956,8 +9094,8 @@ dependencies = [
  "bitvec",
  "derive_more",
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "impl-trait-for-tuples",
  "log",
  "pallet-authority-discovery",
@@ -8980,16 +9118,16 @@ dependencies = [
  "rustc-hex",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-arithmetic",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-keystore",
- "sp-runtime",
+ "sp-api 28.0.0",
+ "sp-application-crypto 32.0.0",
+ "sp-arithmetic 25.0.0",
+ "sp-core 30.0.0",
+ "sp-inherents 28.0.0",
+ "sp-io 32.0.0",
+ "sp-keystore 0.36.0",
+ "sp-runtime 33.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 28.0.0",
  "sp-std",
  "staging-xcm",
  "staging-xcm-executor",
@@ -9005,8 +9143,8 @@ dependencies = [
  "async-trait",
  "frame-benchmarking",
  "frame-benchmarking-cli",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "frame-system-rpc-runtime-api",
  "futures",
  "hex-literal",
@@ -9070,7 +9208,7 @@ dependencies = [
  "sc-consensus-beefy",
  "sc-consensus-grandpa",
  "sc-consensus-slots",
- "sc-executor",
+ "sc-executor 0.34.0",
  "sc-keystore",
  "sc-network",
  "sc-network-common",
@@ -9085,7 +9223,7 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-blockchain",
@@ -9093,21 +9231,21 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-beefy",
  "sp-consensus-grandpa",
- "sp-core",
- "sp-inherents",
- "sp-io",
+ "sp-core 30.0.0",
+ "sp-inherents 28.0.0",
+ "sp-io 32.0.0",
  "sp-keyring",
- "sp-keystore",
+ "sp-keystore 0.36.0",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-session",
- "sp-state-machine",
+ "sp-state-machine 0.37.0",
  "sp-storage",
  "sp-timestamp",
  "sp-transaction-pool",
- "sp-version",
- "sp-weights",
+ "sp-version 31.0.0",
+ "sp-weights 29.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tracing-gum",
@@ -9132,8 +9270,8 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "sp-keystore",
- "sp-staking",
+ "sp-keystore 0.36.0",
+ "sp-staking 28.0.0",
  "thiserror",
  "tracing-gum",
 ]
@@ -9146,7 +9284,7 @@ checksum = "b2fb894021b1318d752d29b1b65721833aa668876e1a780ac760c59d40f5d759"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-core",
+ "sp-core 30.0.0",
  "tracing-gum",
 ]
 
@@ -9989,8 +10127,8 @@ dependencies = [
  "binary-merkle-tree",
  "frame-benchmarking",
  "frame-executive",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -10051,25 +10189,25 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "sp-api",
- "sp-arithmetic",
+ "sp-api 28.0.0",
+ "sp-arithmetic 25.0.0",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-consensus-beefy",
- "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
+ "sp-core 30.0.0",
+ "sp-genesis-builder 0.9.0",
+ "sp-inherents 28.0.0",
+ "sp-io 32.0.0",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 28.0.0",
  "sp-std",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 31.0.0",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -10083,13 +10221,13 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74f036bf3c4f8cc01301dbe91e601e736e1939f42ef7a364058f26752305527e"
 dependencies = [
- "frame-support",
+ "frame-support 30.0.0",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
- "sp-core",
- "sp-runtime",
- "sp-weights",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
+ "sp-weights 29.0.0",
  "staging-xcm",
  "staging-xcm-builder",
 ]
@@ -10376,12 +10514,24 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357127c91373ed6d1ae582f6e3300ab5b13bcde43bbf270a891f44194ef48b70"
+dependencies = [
+ "log",
+ "sp-core 29.0.0",
+ "sp-wasm-interface",
+ "thiserror",
+]
+
+[[package]]
+name = "sc-allocator"
 version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97e78cc21b2bb1d13b33d9c64fbb02a10efde428e8f0a68a0ca2084203123933"
 dependencies = [
  "log",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-wasm-interface",
  "thiserror",
 ]
@@ -10406,12 +10556,12 @@ dependencies = [
  "rand",
  "sc-client-api",
  "sc-network",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-authority-discovery",
  "sp-blockchain",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-keystore 0.36.0",
+ "sp-runtime 33.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10430,12 +10580,12 @@ dependencies = [
  "sc-proposer-metrics",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-inherents 28.0.0",
+ "sp-runtime 33.0.0",
  "substrate-prometheus-endpoint",
 ]
 
@@ -10446,13 +10596,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a2f425079daf382b0f1cf3b9085bed25db13ec8ad0ff64b0dc75ff457c0f7"
 dependencies = [
  "parity-scale-codec",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-block-builder",
  "sp-blockchain",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-trie",
+ "sp-core 30.0.0",
+ "sp-inherents 28.0.0",
+ "sp-runtime 33.0.0",
+ "sp-trie 31.0.0",
 ]
 
 [[package]]
@@ -10468,18 +10618,18 @@ dependencies = [
  "parity-scale-codec",
  "sc-chain-spec-derive",
  "sc-client-api",
- "sc-executor",
+ "sc-executor 0.34.0",
  "sc-network",
  "sc-telemetry",
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-crypto-hashing",
- "sp-genesis-builder",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
+ "sp-genesis-builder 0.9.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
 ]
 
 [[package]]
@@ -10526,12 +10676,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-keyring",
- "sp-keystore",
+ "sp-keystore 0.36.0",
  "sp-panic-handler",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 33.0.0",
+ "sp-version 31.0.0",
  "thiserror",
  "tokio",
 ]
@@ -10547,20 +10697,20 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sc-executor",
+ "sc-executor 0.34.0",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-database",
- "sp-externalities",
- "sp-runtime",
- "sp-state-machine",
+ "sp-externalities 0.27.0",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
  "sp-statement-store",
  "sp-storage",
- "sp-trie",
+ "sp-trie 31.0.0",
  "substrate-prometheus-endpoint",
 ]
 
@@ -10582,13 +10732,13 @@ dependencies = [
  "sc-client-api",
  "sc-state-db",
  "schnellru",
- "sp-arithmetic",
+ "sp-arithmetic 25.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-database",
- "sp-runtime",
- "sp-state-machine",
- "sp-trie",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
+ "sp-trie 31.0.0",
 ]
 
 [[package]]
@@ -10607,12 +10757,12 @@ dependencies = [
  "sc-client-api",
  "sc-utils",
  "serde",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10632,17 +10782,17 @@ dependencies = [
  "sc-consensus",
  "sc-consensus-slots",
  "sc-telemetry",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 28.0.0",
+ "sp-application-crypto 32.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
  "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-keystore",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-inherents 28.0.0",
+ "sp-keystore 0.36.0",
+ "sp-runtime 33.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10668,18 +10818,18 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "sc-transaction-pool-api",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 28.0.0",
+ "sp-application-crypto 32.0.0",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
  "sp-consensus-slots",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-crypto-hashing",
- "sp-inherents",
- "sp-keystore",
- "sp-runtime",
+ "sp-inherents 28.0.0",
+ "sp-keystore 0.36.0",
+ "sp-runtime 33.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10696,14 +10846,14 @@ dependencies = [
  "sc-consensus-epochs",
  "sc-rpc-api",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 28.0.0",
+ "sp-application-crypto 32.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-keystore 0.36.0",
+ "sp-runtime 33.0.0",
  "thiserror",
 ]
 
@@ -10727,17 +10877,17 @@ dependencies = [
  "sc-network-gossip",
  "sc-network-sync",
  "sc-utils",
- "sp-api",
- "sp-application-crypto",
- "sp-arithmetic",
+ "sp-api 28.0.0",
+ "sp-application-crypto 32.0.0",
+ "sp-arithmetic 25.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-beefy",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-crypto-hashing",
- "sp-keystore",
+ "sp-keystore 0.36.0",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -10759,8 +10909,8 @@ dependencies = [
  "sc-rpc",
  "serde",
  "sp-consensus-beefy",
- "sp-core",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "thiserror",
 ]
 
@@ -10775,7 +10925,7 @@ dependencies = [
  "sc-client-api",
  "sc-consensus",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 33.0.0",
 ]
 
 [[package]]
@@ -10808,16 +10958,16 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api",
- "sp-application-crypto",
- "sp-arithmetic",
+ "sp-api 28.0.0",
+ "sp-application-crypto 32.0.0",
+ "sp-arithmetic 25.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-crypto-hashing",
- "sp-keystore",
- "sp-runtime",
+ "sp-keystore 0.36.0",
+ "sp-runtime 33.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10838,8 +10988,8 @@ dependencies = [
  "sc-rpc",
  "serde",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "thiserror",
 ]
 
@@ -10864,16 +11014,16 @@ dependencies = [
  "sc-transaction-pool",
  "sc-transaction-pool-api",
  "serde",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
  "sp-consensus-babe",
  "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-keystore",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-inherents 28.0.0",
+ "sp-keystore 0.36.0",
+ "sp-runtime 33.0.0",
  "sp-timestamp",
  "substrate-prometheus-endpoint",
  "thiserror",
@@ -10893,14 +11043,37 @@ dependencies = [
  "sc-client-api",
  "sc-consensus",
  "sc-telemetry",
- "sp-arithmetic",
+ "sp-arithmetic 25.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 30.0.0",
+ "sp-inherents 28.0.0",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
+]
+
+[[package]]
+name = "sc-executor"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2ac6c356538d67987bbb867e11a12a84ba87250c70fd50005b6d74f570a4f7"
+dependencies = [
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sc-executor-common 0.30.0",
+ "sc-executor-wasmtime 0.30.0",
+ "schnellru",
+ "sp-api 27.0.1",
+ "sp-core 29.0.0",
+ "sp-externalities 0.26.0",
+ "sp-io 31.0.0",
+ "sp-panic-handler",
+ "sp-runtime-interface 25.0.0",
+ "sp-trie 30.0.0",
+ "sp-version 30.0.0",
+ "sp-wasm-interface",
+ "tracing",
 ]
 
 [[package]]
@@ -10911,19 +11084,32 @@ checksum = "a331ae16b0a17ed474eaf9c2dc01b145511cf4bd62ffc165d7dd1d3f13e48a94"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sc-executor-common",
- "sc-executor-wasmtime",
+ "sc-executor-common 0.31.0",
+ "sc-executor-wasmtime 0.31.0",
  "schnellru",
- "sp-api",
- "sp-core",
- "sp-externalities",
- "sp-io",
+ "sp-api 28.0.0",
+ "sp-core 30.0.0",
+ "sp-externalities 0.27.0",
+ "sp-io 32.0.0",
  "sp-panic-handler",
- "sp-runtime-interface",
- "sp-trie",
- "sp-version",
+ "sp-runtime-interface 26.0.0",
+ "sp-trie 31.0.0",
+ "sp-version 31.0.0",
  "sp-wasm-interface",
  "tracing",
+]
+
+[[package]]
+name = "sc-executor-common"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07498138dee3ddf2c71299ca372d8449880bb3a8a8a299a483094e9c26b0823e"
+dependencies = [
+ "sc-allocator 24.0.0",
+ "sp-maybe-compressed-blob",
+ "sp-wasm-interface",
+ "thiserror",
+ "wasm-instrument",
 ]
 
 [[package]]
@@ -10932,11 +11118,30 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f414028dc468aafd449cb659f7664e39540f3308945ec9cf2209c1359fa67e"
 dependencies = [
- "sc-allocator",
- "sp-maybe-compressed-blob 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sc-allocator 25.0.0",
+ "sp-maybe-compressed-blob",
  "sp-wasm-interface",
  "thiserror",
  "wasm-instrument",
+]
+
+[[package]]
+name = "sc-executor-wasmtime"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a387779ab54ec1ffce0bf3a6631faada079459d42796c1895683767918a642"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "log",
+ "parking_lot 0.12.3",
+ "rustix 0.36.17",
+ "sc-allocator 24.0.0",
+ "sc-executor-common 0.30.0",
+ "sp-runtime-interface 25.0.0",
+ "sp-wasm-interface",
+ "wasmtime",
 ]
 
 [[package]]
@@ -10951,9 +11156,9 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "rustix 0.36.17",
- "sc-allocator",
- "sc-executor-common",
- "sp-runtime-interface",
+ "sc-allocator 25.0.0",
+ "sc-executor-common 0.31.0",
+ "sp-runtime-interface 26.0.0",
  "sp-wasm-interface",
  "wasmtime",
 ]
@@ -10973,7 +11178,7 @@ dependencies = [
  "sc-network-common",
  "sc-network-sync",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 33.0.0",
 ]
 
 [[package]]
@@ -10985,9 +11190,9 @@ dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.3",
  "serde_json",
- "sp-application-crypto",
- "sp-core",
- "sp-keystore",
+ "sp-application-crypto 32.0.0",
+ "sp-core 30.0.0",
+ "sp-keystore 0.36.0",
  "thiserror",
 ]
 
@@ -11012,12 +11217,12 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-consensus",
- "sp-core",
- "sp-keystore",
+ "sp-core 30.0.0",
+ "sp-keystore 0.36.0",
  "sp-mixnet",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "thiserror",
 ]
 
@@ -11052,10 +11257,10 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-arithmetic",
+ "sp-arithmetic 25.0.0",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -11081,7 +11286,7 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "thiserror",
  "unsigned-varint 0.7.2",
 ]
@@ -11101,7 +11306,7 @@ dependencies = [
  "sc-consensus",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-runtime",
+ "sp-runtime 33.0.0",
 ]
 
 [[package]]
@@ -11119,7 +11324,7 @@ dependencies = [
  "sc-network-common",
  "sc-network-sync",
  "schnellru",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -11141,8 +11346,8 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "thiserror",
 ]
 
@@ -11171,12 +11376,12 @@ dependencies = [
  "sc-utils",
  "schnellru",
  "smallvec",
- "sp-arithmetic",
+ "sp-arithmetic 25.0.0",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-core",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -11199,7 +11404,7 @@ dependencies = [
  "sc-network-sync",
  "sc-utils",
  "sp-consensus",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "substrate-prometheus-endpoint",
 ]
 
@@ -11228,12 +11433,12 @@ dependencies = [
  "sc-network-common",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api",
- "sp-core",
- "sp-externalities",
- "sp-keystore",
+ "sp-api 28.0.0",
+ "sp-core 30.0.0",
+ "sp-externalities 0.27.0",
+ "sp-keystore 0.36.0",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "threadpool",
  "tracing",
 ]
@@ -11268,16 +11473,16 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
- "sp-core",
- "sp-keystore",
+ "sp-core 30.0.0",
+ "sp-keystore 0.36.0",
  "sp-offchain",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-session",
  "sp-statement-store",
- "sp-version",
+ "sp-version 31.0.0",
  "tokio",
 ]
 
@@ -11295,10 +11500,10 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-rpc",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 33.0.0",
+ "sp-version 31.0.0",
  "thiserror",
 ]
 
@@ -11343,12 +11548,12 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-rpc",
- "sp-runtime",
- "sp-version",
+ "sp-runtime 33.0.0",
+ "sp-version 31.0.0",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -11375,7 +11580,7 @@ dependencies = [
  "sc-client-api",
  "sc-client-db",
  "sc-consensus",
- "sc-executor",
+ "sc-executor 0.34.0",
  "sc-informant",
  "sc-keystore",
  "sc-network",
@@ -11395,20 +11600,20 @@ dependencies = [
  "sc-utils",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-externalities",
- "sp-keystore",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-externalities 0.27.0",
+ "sp-keystore 0.36.0",
+ "sp-runtime 33.0.0",
  "sp-session",
- "sp-state-machine",
+ "sp-state-machine 0.37.0",
  "sp-storage",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
- "sp-trie",
- "sp-version",
+ "sp-trie 31.0.0",
+ "sp-version 31.0.0",
  "static_init",
  "substrate-prometheus-endpoint",
  "tempfile",
@@ -11427,7 +11632,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sp-core",
+ "sp-core 30.0.0",
 ]
 
 [[package]]
@@ -11439,7 +11644,7 @@ dependencies = [
  "clap",
  "fs4",
  "log",
- "sp-core",
+ "sp-core 30.0.0",
  "thiserror",
  "tokio",
 ]
@@ -11460,7 +11665,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "thiserror",
 ]
 
@@ -11480,9 +11685,9 @@ dependencies = [
  "sc-telemetry",
  "serde",
  "serde_json",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-crypto-hashing",
- "sp-io",
+ "sp-io 32.0.0",
  "sp-std",
 ]
 
@@ -11525,11 +11730,11 @@ dependencies = [
  "sc-client-api",
  "sc-tracing-proc-macro",
  "serde",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-tracing",
  "thiserror",
  "tracing",
@@ -11566,11 +11771,11 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-blockchain",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-crypto-hashing",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-tracing",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
@@ -11589,8 +11794,8 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "thiserror",
 ]
 
@@ -11607,7 +11812,30 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "prometheus",
- "sp-arithmetic",
+ "sp-arithmetic 25.0.0",
+]
+
+[[package]]
+name = "scale-bits"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
+dependencies = [
+ "parity-scale-codec",
+ "scale-type-resolver",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e98f3262c250d90e700bb802eb704e1f841e03331c2eb815e46516c4edbf5b27"
+dependencies = [
+ "derive_more",
+ "parity-scale-codec",
+ "scale-bits",
+ "scale-type-resolver",
+ "smallvec",
 ]
 
 [[package]]
@@ -11635,6 +11863,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "scale-type-resolver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0cded6518aa0bd6c1be2b88ac81bf7044992f0f154bfbabd5ad34f43512abcb"
 
 [[package]]
 name = "schannel"
@@ -12024,7 +12258,7 @@ dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -12212,6 +12446,28 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
+version = "27.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4f8702afd77f14a32733e2b589c02694bf79d0b3a641963c508016208724d0"
+dependencies = [
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api-proc-macro 15.0.1",
+ "sp-core 29.0.0",
+ "sp-externalities 0.26.0",
+ "sp-metadata-ir",
+ "sp-runtime 32.0.0",
+ "sp-state-machine 0.36.0",
+ "sp-std",
+ "sp-trie 30.0.0",
+ "sp-version 30.0.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-api"
 version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "298331cb47a948244f6fb4921b5cbeece267d72139fb90760993b6ec37b2212c"
@@ -12220,17 +12476,32 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api-proc-macro",
- "sp-core",
- "sp-externalities",
+ "sp-api-proc-macro 16.0.0",
+ "sp-core 30.0.0",
+ "sp-externalities 0.27.0",
  "sp-metadata-ir",
- "sp-runtime",
- "sp-runtime-interface",
- "sp-state-machine",
+ "sp-runtime 33.0.0",
+ "sp-runtime-interface 26.0.0",
+ "sp-state-machine 0.37.0",
  "sp-std",
- "sp-trie",
- "sp-version",
+ "sp-trie 31.0.0",
+ "sp-version 31.0.0",
  "thiserror",
+]
+
+[[package]]
+name = "sp-api-proc-macro"
+version = "15.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0301e2f77afb450fbf2b093f8b324c7ad88cc82e5e69bd5dc8658a1f068b2a96"
+dependencies = [
+ "Inflector",
+ "blake2 0.10.6",
+ "expander 2.2.1",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -12250,6 +12521,20 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "547cad7a6eabb52c639ec117b3db9c6b43cf1b29a9393b18feb19e101a91833f"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-application-crypto"
 version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b4b7b12922cb90cf8dff0cab14087ba0ca25c1f04ba060c7294ce42c78d89ab"
@@ -12257,9 +12542,24 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
  "sp-std",
+]
+
+[[package]]
+name = "sp-arithmetic"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa823ca5adc490d47dccb41d69ad482bc57a317bd341de275868378f48f131c"
+dependencies = [
+ "integer-sqrt",
+ "num-traits",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-std",
+ "static_assertions",
 ]
 
 [[package]]
@@ -12285,9 +12585,9 @@ checksum = "0addabbce9f90c614145067139122420cfc940c495d2c3c1acc4a3b5f392f914"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
- "sp-runtime",
+ "sp-api 28.0.0",
+ "sp-application-crypto 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -12297,9 +12597,9 @@ version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b35d0992e2183686215dccb4bcb5003b4eb52feec82d82dabd81db7401d845a"
 dependencies = [
- "sp-api",
- "sp-inherents",
- "sp-runtime",
+ "sp-api 28.0.0",
+ "sp-inherents 28.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -12314,11 +12614,11 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "schnellru",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-consensus",
  "sp-database",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
  "thiserror",
 ]
 
@@ -12331,10 +12631,10 @@ dependencies = [
  "async-trait",
  "futures",
  "log",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 30.0.0",
+ "sp-inherents 28.0.0",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
  "thiserror",
 ]
 
@@ -12347,11 +12647,11 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 28.0.0",
+ "sp-application-crypto 32.0.0",
  "sp-consensus-slots",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 28.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
  "sp-timestamp",
 ]
@@ -12366,12 +12666,12 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 28.0.0",
+ "sp-application-crypto 32.0.0",
  "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-inherents 28.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
  "sp-timestamp",
 ]
@@ -12386,14 +12686,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
+ "sp-api 28.0.0",
+ "sp-application-crypto 32.0.0",
+ "sp-core 30.0.0",
  "sp-crypto-hashing",
- "sp-io",
- "sp-keystore",
+ "sp-io 32.0.0",
+ "sp-keystore 0.36.0",
  "sp-mmr-primitives",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
  "strum 0.24.1",
 ]
@@ -12409,11 +12709,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
+ "sp-api 28.0.0",
+ "sp-application-crypto 32.0.0",
+ "sp-core 30.0.0",
+ "sp-keystore 0.36.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -12428,6 +12728,52 @@ dependencies = [
  "serde",
  "sp-std",
  "sp-timestamp",
+]
+
+[[package]]
+name = "sp-core"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c33c7a1568175250628567d50c4e1c54a6ac5bc1190413b9be29a9e810cbe73"
+dependencies = [
+ "array-bytes 6.2.3",
+ "bip39",
+ "bitflags 1.3.2",
+ "blake2 0.10.6",
+ "bounded-collections",
+ "bs58 0.5.1",
+ "dyn-clonable",
+ "ed25519-zebra 3.1.0",
+ "futures",
+ "hash-db",
+ "hash256-std-hasher",
+ "impl-serde",
+ "itertools 0.10.5",
+ "libsecp256k1",
+ "log",
+ "merlin",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "paste",
+ "primitive-types",
+ "rand",
+ "scale-info",
+ "schnorrkel 0.11.4",
+ "secp256k1",
+ "secrecy",
+ "serde",
+ "sp-crypto-hashing",
+ "sp-debug-derive",
+ "sp-externalities 0.26.0",
+ "sp-runtime-interface 25.0.0",
+ "sp-std",
+ "sp-storage",
+ "ss58-registry",
+ "substrate-bip39",
+ "thiserror",
+ "tracing",
+ "w3f-bls",
+ "zeroize",
 ]
 
 [[package]]
@@ -12464,8 +12810,8 @@ dependencies = [
  "serde",
  "sp-crypto-hashing",
  "sp-debug-derive",
- "sp-externalities",
- "sp-runtime-interface",
+ "sp-externalities 0.27.0",
+ "sp-runtime-interface 26.0.0",
  "sp-std",
  "sp-storage",
  "ss58-registry",
@@ -12524,6 +12870,18 @@ dependencies = [
 
 [[package]]
 name = "sp-externalities"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7096ed024cec397804864898b093b51e14c7299f1d00c67dd5800330e02bb82"
+dependencies = [
+ "environmental",
+ "parity-scale-codec",
+ "sp-std",
+ "sp-storage",
+]
+
+[[package]]
+name = "sp-externalities"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d6a4572eadd4a63cff92509a210bf425501a0c5e76574b30a366ac77653787"
@@ -12536,14 +12894,41 @@ dependencies = [
 
 [[package]]
 name = "sp-genesis-builder"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd865540ec19479c7349b584ccd78cc34c3f3a628a2a69dbb6365ceec36295ee"
+dependencies = [
+ "serde_json",
+ "sp-api 27.0.1",
+ "sp-runtime 32.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-genesis-builder"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a862db099e8a799417b63ea79c90079811cdf68fcf3013d81cdceeddcec8f142"
 dependencies = [
  "serde_json",
- "sp-api",
- "sp-runtime",
+ "sp-api 28.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
+]
+
+[[package]]
+name = "sp-inherents"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "607c9e35e96966645ff180a9e9f976433b96e905d0a91d8d5315e605a21f4bc0"
+dependencies = [
+ "async-trait",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 32.0.0",
+ "sp-std",
+ "thiserror",
 ]
 
 [[package]]
@@ -12556,9 +12941,35 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
  "thiserror",
+]
+
+[[package]]
+name = "sp-io"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec43aa073eab35fcb920d7592474d5427ea3be2bf938706a3ad955d7ba54fd8d"
+dependencies = [
+ "bytes",
+ "ed25519-dalek",
+ "libsecp256k1",
+ "log",
+ "parity-scale-codec",
+ "rustversion",
+ "secp256k1",
+ "sp-core 29.0.0",
+ "sp-crypto-hashing",
+ "sp-externalities 0.26.0",
+ "sp-keystore 0.35.0",
+ "sp-runtime-interface 25.0.0",
+ "sp-state-machine 0.36.0",
+ "sp-std",
+ "sp-tracing",
+ "sp-trie 30.0.0",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]
@@ -12574,15 +12985,15 @@ dependencies = [
  "parity-scale-codec",
  "rustversion",
  "secp256k1",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-crypto-hashing",
- "sp-externalities",
- "sp-keystore",
- "sp-runtime-interface",
- "sp-state-machine",
+ "sp-externalities 0.27.0",
+ "sp-keystore 0.36.0",
+ "sp-runtime-interface 26.0.0",
+ "sp-state-machine 0.37.0",
  "sp-std",
  "sp-tracing",
- "sp-trie",
+ "sp-trie 31.0.0",
  "tracing",
  "tracing-core",
 ]
@@ -12593,9 +13004,22 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f9c74648e593b45309dfddf34f4edfd0a91816d1d97dd5e0bd93c46e7cdb0d6"
 dependencies = [
- "sp-core",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "strum 0.24.1",
+]
+
+[[package]]
+name = "sp-keystore"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444f2d53968b1ce5e908882710ff1f3873fcf3e95f59d57432daf685bbacb959"
+dependencies = [
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sp-core 29.0.0",
+ "sp-externalities 0.26.0",
+ "thiserror",
 ]
 
 [[package]]
@@ -12606,8 +13030,8 @@ checksum = "bd4bf9e5fa486416c92c2bb497b7ce2c43eac80cbdc407ffe2d34b365694ac29"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sp-core",
- "sp-externalities",
+ "sp-core 30.0.0",
+ "sp-externalities 0.27.0",
 ]
 
 [[package]]
@@ -12615,15 +13039,6 @@ name = "sp-maybe-compressed-blob"
 version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c768c11afbe698a090386876911da4236af199cd38a5866748df4d8628aeff"
-dependencies = [
- "thiserror",
- "zstd 0.12.4",
-]
-
-[[package]]
-name = "sp-maybe-compressed-blob"
-version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.8.0#a51b5dd3dd7d00b0c0ae5bdd28650eb13f0ae70c"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -12649,8 +13064,8 @@ checksum = "15a8078f19b1292220b7110115b49f4fcd427324f3b184f6d8dbeb6b4dd40d4d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-application-crypto",
+ "sp-api 28.0.0",
+ "sp-application-crypto 32.0.0",
  "sp-std",
 ]
 
@@ -12665,10 +13080,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api",
- "sp-core",
+ "sp-api 28.0.0",
+ "sp-core 30.0.0",
  "sp-debug-derive",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
  "thiserror",
 ]
@@ -12682,9 +13097,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic",
- "sp-core",
- "sp-runtime",
+ "sp-arithmetic 25.0.0",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -12694,9 +13109,9 @@ version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f826efe7bdd6d142ced34f5ef1ed9a2070887e78d3146220250edeb67e6791d5"
 dependencies = [
- "sp-api",
- "sp-core",
- "sp-runtime",
+ "sp-api 28.0.0",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
 ]
 
 [[package]]
@@ -12718,7 +13133,32 @@ checksum = "ffa9924fc1d0e7b79550493b8b8ac3fa58593cbdb169ee6cf6c1ee3ef25882dd"
 dependencies = [
  "rustc-hash",
  "serde",
- "sp-core",
+ "sp-core 30.0.0",
+]
+
+[[package]]
+name = "sp-runtime"
+version = "32.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a95e71603a6281e91b0f1fd3d68057644be16d75a4602013187b8137db8abee"
+dependencies = [
+ "docify",
+ "either",
+ "hash256-std-hasher",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "paste",
+ "rand",
+ "scale-info",
+ "serde",
+ "simple-mermaid",
+ "sp-application-crypto 31.0.0",
+ "sp-arithmetic 24.0.0",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-std",
+ "sp-weights 28.0.0",
 ]
 
 [[package]]
@@ -12738,12 +13178,31 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
+ "sp-application-crypto 32.0.0",
+ "sp-arithmetic 25.0.0",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
  "sp-std",
- "sp-weights",
+ "sp-weights 29.0.0",
+]
+
+[[package]]
+name = "sp-runtime-interface"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2321ab29d4bcc31f1ba1b4f076a81fb2a666465231e5c981c72320d74dbe63"
+dependencies = [
+ "bytes",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "primitive-types",
+ "sp-externalities 0.26.0",
+ "sp-runtime-interface-proc-macro 17.0.0",
+ "sp-std",
+ "sp-storage",
+ "sp-tracing",
+ "sp-wasm-interface",
+ "static_assertions",
 ]
 
 [[package]]
@@ -12757,13 +13216,27 @@ dependencies = [
  "parity-scale-codec",
  "polkavm-derive",
  "primitive-types",
- "sp-externalities",
- "sp-runtime-interface-proc-macro",
+ "sp-externalities 0.27.0",
+ "sp-runtime-interface-proc-macro 18.0.0",
  "sp-std",
  "sp-storage",
  "sp-tracing",
  "sp-wasm-interface",
  "static_assertions",
+]
+
+[[package]]
+name = "sp-runtime-interface-proc-macro"
+version = "17.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfaf6e85b2ec12a4b99cd6d8d57d083e30c94b7f1b0d8f93547121495aae6f0c"
+dependencies = [
+ "Inflector",
+ "expander 2.2.1",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -12788,11 +13261,26 @@ checksum = "0399eb885209b51b2999fe35883a579b0848674f0679019ce262f19d0a853325"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
- "sp-staking",
+ "sp-api 28.0.0",
+ "sp-core 30.0.0",
+ "sp-keystore 0.36.0",
+ "sp-runtime 33.0.0",
+ "sp-staking 28.0.0",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-staking"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e14d003ecf0b610bf1305a92bdab875289b39d514c073f30e75e78c2763a788"
+dependencies = [
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 29.0.0",
+ "sp-runtime 32.0.0",
  "sp-std",
 ]
 
@@ -12806,9 +13294,31 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
+]
+
+[[package]]
+name = "sp-state-machine"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a67297e702aa32027d7766803f362a420d6d3ec9e2f84961f3c64e2e52b5aaf9"
+dependencies = [
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "rand",
+ "smallvec",
+ "sp-core 29.0.0",
+ "sp-externalities 0.26.0",
+ "sp-panic-handler",
+ "sp-std",
+ "sp-trie 30.0.0",
+ "thiserror",
+ "tracing",
+ "trie-db",
 ]
 
 [[package]]
@@ -12823,11 +13333,11 @@ dependencies = [
  "parking_lot 0.12.3",
  "rand",
  "smallvec",
- "sp-core",
- "sp-externalities",
+ "sp-core 30.0.0",
+ "sp-externalities 0.27.0",
  "sp-panic-handler",
  "sp-std",
- "sp-trie",
+ "sp-trie 31.0.0",
  "thiserror",
  "tracing",
  "trie-db",
@@ -12847,13 +13357,13 @@ dependencies = [
  "rand",
  "scale-info",
  "sha2 0.10.8",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
+ "sp-api 28.0.0",
+ "sp-application-crypto 32.0.0",
+ "sp-core 30.0.0",
  "sp-crypto-hashing",
- "sp-externalities",
- "sp-runtime",
- "sp-runtime-interface",
+ "sp-externalities 0.27.0",
+ "sp-runtime 33.0.0",
+ "sp-runtime-interface 26.0.0",
  "sp-std",
  "thiserror",
  "x25519-dalek 2.0.1",
@@ -12887,8 +13397,8 @@ checksum = "ee9532c2e4c8fcd7753cb4c741daeb8d9e3ac7cbc15a84c78d4c96492ed20eba"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 28.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
  "thiserror",
 ]
@@ -12912,8 +13422,8 @@ version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8e8b3208d1c8347ab75b28192dc7354489369ae652f2d9936521c8ccd92ca06"
 dependencies = [
- "sp-api",
- "sp-runtime",
+ "sp-api 28.0.0",
+ "sp-runtime 33.0.0",
 ]
 
 [[package]]
@@ -12925,11 +13435,36 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-inherents 28.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
- "sp-trie",
+ "sp-trie 31.0.0",
+]
+
+[[package]]
+name = "sp-trie"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed48dfd05081e8b36741b10ce4eb686c135a2952227a11fe71caec89890ddbb"
+dependencies = [
+ "ahash 0.8.11",
+ "hash-db",
+ "lazy_static",
+ "memory-db",
+ "nohash-hasher",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "rand",
+ "scale-info",
+ "schnellru",
+ "sp-core 29.0.0",
+ "sp-externalities 0.26.0",
+ "sp-std",
+ "thiserror",
+ "tracing",
+ "trie-db",
+ "trie-root",
 ]
 
 [[package]]
@@ -12948,13 +13483,31 @@ dependencies = [
  "rand",
  "scale-info",
  "schnellru",
- "sp-core",
- "sp-externalities",
+ "sp-core 30.0.0",
+ "sp-externalities 0.27.0",
  "sp-std",
  "thiserror",
  "tracing",
  "trie-db",
  "trie-root",
+]
+
+[[package]]
+name = "sp-version"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4a660c68995663d6778df324f4e2b4efc48d55a8e9c92c22a5fb7dae7899cd"
+dependencies = [
+ "impl-serde",
+ "parity-scale-codec",
+ "parity-wasm",
+ "scale-info",
+ "serde",
+ "sp-crypto-hashing-proc-macro",
+ "sp-runtime 32.0.0",
+ "sp-std",
+ "sp-version-proc-macro",
+ "thiserror",
 ]
 
 [[package]]
@@ -12969,7 +13522,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-crypto-hashing-proc-macro",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
  "sp-version-proc-macro",
  "thiserror",
@@ -13003,6 +13556,22 @@ dependencies = [
 
 [[package]]
 name = "sp-weights"
+version = "28.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3be30aec904994451dcacf841a9168cfbbaf817de6b24b6a1c1418cbf1af2fe"
+dependencies = [
+ "bounded-collections",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "smallvec",
+ "sp-arithmetic 24.0.0",
+ "sp-debug-derive",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-weights"
 version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8a9c7a1b64fa7dba38622ad1de26f0b2e595727c0e42c7b109ecb8e7120688"
@@ -13012,7 +13581,7 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
- "sp-arithmetic",
+ "sp-arithmetic 25.0.0",
  "sp-debug-derive",
  "sp-std",
 ]
@@ -13087,11 +13656,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ea840dfaa900fe1d6fef60bdfb446b1a03101a1c2620f50c7d43443b93df207"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -13110,7 +13679,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-weights",
+ "sp-weights 29.0.0",
  "xcm-procedural",
 ]
 
@@ -13120,19 +13689,19 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea27e235bcca331e5ba693fd224fcc16c17b53f53fca875c8dc54b733dba3c6"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "impl-trait-for-tuples",
  "log",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "scale-info",
- "sp-arithmetic",
- "sp-io",
- "sp-runtime",
+ "sp-arithmetic 25.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
- "sp-weights",
+ "sp-weights 29.0.0",
  "staging-xcm",
  "staging-xcm-executor",
 ]
@@ -13145,17 +13714,17 @@ checksum = "fe8c62fe1eee71592828a513693106ff301cdafd5ac5bd52e06d9315fd4f4f7a"
 dependencies = [
  "environmental",
  "frame-benchmarking",
- "frame-support",
+ "frame-support 30.0.0",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
+ "sp-arithmetic 25.0.0",
+ "sp-core 30.0.0",
+ "sp-io 32.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
- "sp-weights",
+ "sp-weights 29.0.0",
  "staging-xcm",
 ]
 
@@ -13285,11 +13854,11 @@ dependencies = [
  "parity-scale-codec",
  "sc-rpc-api",
  "sc-transaction-pool-api",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-block-builder",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
 ]
 
 [[package]]
@@ -13316,7 +13885,7 @@ dependencies = [
  "log",
  "sc-rpc-api",
  "serde",
- "sp-runtime",
+ "sp-runtime 33.0.0",
 ]
 
 [[package]]
@@ -13330,25 +13899,34 @@ dependencies = [
  "sc-client-api",
  "sc-rpc-api",
  "serde",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
- "sp-trie",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
+ "sp-trie 31.0.0",
  "trie-db",
 ]
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.8.0#a51b5dd3dd7d00b0c0ae5bdd28650eb13f0ae70c"
+version = "18.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a39a20e17c24ede36b5bd5e7543a4cef8d8a0daf6e1a046dc31832b837a54a0"
 dependencies = [
+ "array-bytes 6.2.3",
  "build-helper",
  "cargo_metadata",
  "console",
  "filetime",
+ "frame-metadata",
+ "merkleized-metadata",
+ "parity-scale-codec",
  "parity-wasm",
- "polkavm-linker",
- "sp-maybe-compressed-blob 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.8.0)",
+ "sc-executor 0.33.0",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
+ "sp-maybe-compressed-blob",
+ "sp-tracing",
+ "sp-version 30.0.0",
  "strum 0.24.1",
  "tempfile",
  "toml 0.8.14",
@@ -13368,7 +13946,7 @@ dependencies = [
  "filetime",
  "parity-wasm",
  "polkavm-linker",
- "sp-maybe-compressed-blob 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-maybe-compressed-blob",
  "strum 0.24.1",
  "tempfile",
  "toml 0.8.14",
@@ -13454,11 +14032,11 @@ name = "system-runtime-api"
 version = "0.0.0"
 dependencies = [
  "common-primitives",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "serde_json",
- "sp-api",
- "sp-runtime",
+ "sp-api 28.0.0",
+ "sp-runtime 33.0.0",
  "sp-std",
 ]
 
@@ -14063,25 +14641,25 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "sc-cli",
- "sc-executor",
+ "sc-executor 0.34.0",
  "serde",
  "serde_json",
- "sp-api",
+ "sp-api 28.0.0",
  "sp-consensus-aura",
  "sp-consensus-babe",
- "sp-core",
+ "sp-core 30.0.0",
  "sp-debug-derive",
- "sp-externalities",
- "sp-inherents",
- "sp-io",
- "sp-keystore",
+ "sp-externalities 0.27.0",
+ "sp-inherents 28.0.0",
+ "sp-io 32.0.0",
+ "sp-keystore 0.36.0",
  "sp-rpc",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 33.0.0",
+ "sp-state-machine 0.37.0",
  "sp-timestamp",
  "sp-transaction-storage-proof",
- "sp-version",
- "sp-weights",
+ "sp-version 31.0.0",
+ "sp-weights 29.0.0",
  "substrate-rpc-client",
  "zstd 0.12.4",
 ]
@@ -14747,8 +15325,8 @@ dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",
- "frame-support",
- "frame-system",
+ "frame-support 30.0.0",
+ "frame-system 30.0.0",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -14815,27 +15393,27 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "sp-api",
- "sp-application-crypto",
- "sp-arithmetic",
+ "sp-api 28.0.0",
+ "sp-application-crypto 32.0.0",
+ "sp-arithmetic 25.0.0",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-consensus-beefy",
- "sp-core",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
+ "sp-core 30.0.0",
+ "sp-genesis-builder 0.9.0",
+ "sp-inherents 28.0.0",
+ "sp-io 32.0.0",
  "sp-mmr-primitives",
  "sp-npos-elections",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 33.0.0",
  "sp-session",
- "sp-staking",
+ "sp-staking 28.0.0",
  "sp-std",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 31.0.0",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -14849,13 +15427,13 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4143f3b5d631cb2bc1e0c4a4284dca4861ba0fcc62bfe861e505ff43fa1aa3dc"
 dependencies = [
- "frame-support",
+ "frame-support 30.0.0",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
- "sp-core",
- "sp-runtime",
- "sp-weights",
+ "sp-core 30.0.0",
+ "sp-runtime 33.0.0",
+ "sp-weights 29.0.0",
  "staging-xcm",
  "staging-xcm-builder",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ parity-scale-codec = { version = "3.6.12", default-features = false }
 frame-benchmarking = { version = "30.0.0", default-features = false }
 frame-executive = { version = "30.0.0", default-features = false }
 frame-support = { version = "30.0.0", default-features = false }
-# frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.8.0", default-features = false }
+frame-metadata-hash-extension = { version = "0.1.0", default-features = false }
 frame-system = { version = "30.0.0", default-features = false }
 frame-system-benchmarking = { version = "30.0.0", default-features = false }
 frame-system-rpc-runtime-api = { version = "28.0.0", default-features = false }
@@ -155,6 +155,7 @@ substrate-test-utils = { version = "3.0.0" }
 
 substrate-frame-rpc-system = { version = "30.0.0" }
 substrate-prometheus-endpoint = { version = "0.17.0" }
+substrate-wasm-builder = { version = "18.0.1" }
 try-runtime-cli = { version = "0.40.0" }
 
 [profile.release]

--- a/runtime/frequency/Cargo.toml
+++ b/runtime/frequency/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.0.0"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.8.0"}
+substrate-wasm-builder = { workspace = true, optional = true }
 
 [dependencies]
 parity-scale-codec = { workspace = true, features = ["derive"] }
@@ -30,6 +30,7 @@ frame-system = { workspace = true }
 frame-system-benchmarking = { workspace = true, optional = true }
 frame-system-rpc-runtime-api = { workspace = true }
 frame-try-runtime = { workspace = true, optional = true }
+frame-metadata-hash-extension = { workspace = true }
 
 pallet-aura = { workspace = true }
 pallet-authorship = { workspace = true }
@@ -108,6 +109,7 @@ std = [
   "frame-support/std",
   "frame-system-rpc-runtime-api/std",
   "frame-system/std",
+  "frame-metadata-hash-extension/std",
   "log/std",
   "pallet-aura/std",
   "pallet-authorship/std",
@@ -160,6 +162,7 @@ std = [
   "sp-transaction-pool/std",
   "sp-genesis-builder/std",
   "common-runtime/std",
+  "substrate-wasm-builder",
   "sp-version/std",
   "system-runtime-api/std",
 ]
@@ -238,4 +241,7 @@ frequency-local = ["common-runtime/frequency-local"]
 frequency-no-relay = ["common-runtime/frequency-no-relay"]
 # Following features are used in generating lean wasms
 no-metadata-docs = ["frame-support/no-metadata-docs"]
-on-chain-release-build = ["sp-api/disable-logging"]
+on-chain-release-build = ["sp-api/disable-logging", "metadata-hash"]
+
+# Enable metadata hash generation at compile time for the `CheckMetadataHash` extension.
+metadata-hash = ["substrate-wasm-builder?/metadata-hash"]

--- a/runtime/frequency/Cargo.toml
+++ b/runtime/frequency/Cargo.toml
@@ -241,7 +241,7 @@ frequency-local = ["common-runtime/frequency-local"]
 frequency-no-relay = ["common-runtime/frequency-no-relay"]
 # Following features are used in generating lean wasms
 no-metadata-docs = ["frame-support/no-metadata-docs"]
-on-chain-release-build = ["sp-api/disable-logging", "metadata-hash"]
+on-chain-release-build = ["metadata-hash", "sp-api/disable-logging"]
 
 # Enable metadata hash generation at compile time for the `CheckMetadataHash` extension.
-metadata-hash = ["substrate-wasm-builder?/metadata-hash"]
+metadata-hash = ["substrate-wasm-builder/metadata-hash"]

--- a/runtime/frequency/build.rs
+++ b/runtime/frequency/build.rs
@@ -1,12 +1,14 @@
-use substrate_wasm_builder::WasmBuilder;
-
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
-	// VSCode Users: Uncomment the following line to disable the ANSI color codes.
-	// The OUTPUT pane does not understand ANSI color codes and will show garbage without this.
-	// std::env::set_var("WASM_BUILD_NO_COLOR", "1");
-	WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults()
+}
+
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
+fn main() {
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.enable_metadata_hash("FRQCY", 8)
 		.build()
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -298,6 +298,7 @@ pub type SignedExtra = (
 	pallet_frequency_tx_payment::ChargeFrqTransactionPayment<Runtime>,
 	pallet_msa::CheckFreeExtrinsicUse<Runtime>,
 	pallet_handles::handles_signed_extension::HandlesSignedExtension<Runtime>,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 /// A Block signed with a Justification
 pub type SignedBlock = generic::SignedBlock<Block>;


### PR DESCRIPTION
Add a new signed extension that enables the metadata hash verification feature approved under [RFC 0078](https://polkadot-fellows.github.io/RFCs/approved/0078-merkleized-metadata.html#rfc-0078-merkleized-metadata). This enhancement will support the new generic ledger hardware wallet app and future hardware wallets within the Polkadot ecosystem.