### PR TITLE
passkey: whitelisted capacity

### DIFF
--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -286,7 +286,8 @@ impl Contains<RuntimeCall> for PasskeyCallFilter {
 
 			RuntimeCall::Balances(pallet_balances::Call::transfer_keep_alive { .. }) |
 			RuntimeCall::Balances(pallet_balances::Call::transfer_allow_death { .. }) |
-			RuntimeCall::Balances(pallet_balances::Call::transfer_all { .. }) => true,
+			RuntimeCall::Balances(pallet_balances::Call::transfer_all { .. }) |
+			RuntimeCall::Capacity(_) => true,
 			_ => false,
 		}
 	}
@@ -363,7 +364,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("frequency"),
 	impl_name: create_runtime_str!("frequency"),
 	authoring_version: 1,
-	spec_version: 99,
+	spec_version: 100,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -377,7 +378,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("frequency-testnet"),
 	impl_name: create_runtime_str!("frequency"),
 	authoring_version: 1,
-	spec_version: 99,
+	spec_version: 100,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
# Goal
The goal of this PR is whitelist Capacity pallet transactions for passkey.

Closes  #2032

# Discussion
- I checked `TransactionPayment` pallet and there were no extrinsics on that pallet so there were no reason to whitelist it
- I checked `FrequencyTxPayment` pallet and there were no token based extrinsics as far as I checked so it was also not included.

# Checklist
- [X] Spec version incremented?
