### PR TITLE
Bug fix capacity e2e test

### DIFF
--- a/e2e/capacity/change_staking_target.test.ts
+++ b/e2e/capacity/change_staking_target.test.ts
@@ -8,11 +8,8 @@ import {
   stakeToProvider,
   CENTS,
   DOLLARS,
-  createAndFundKeypair,
   createProviderKeysAndId,
-  getNonce,
 } from '../scaffolding/helpers';
-import { KeyringPair } from '@polkadot/keyring/types';
 
 const fundingSource = getFundingSource('capacity-change-staking-target');
 

--- a/e2e/scaffolding/helpers.ts
+++ b/e2e/scaffolding/helpers.ts
@@ -463,6 +463,7 @@ export async function boostProvider(
     return Promise.reject('stakeToProvider: stakeEvent should be capacity.Staked event');
   }
 }
+
 export async function getNextEpochBlock() {
   const epochInfo = await ExtrinsicHelper.apiPromise.query.capacity.currentEpochInfo();
   const actualEpochLength = await ExtrinsicHelper.apiPromise.query.capacity.epochLength();

--- a/js/api-augment/definitions/capacity.ts
+++ b/js/api-augment/definitions/capacity.ts
@@ -4,8 +4,6 @@ export default {
   },
   types: {
     RewardEra: 'u32',
-    Balance: 'u128',
-    BlockNumber: 'u32',
     UnclaimedRewardInfo: {
       reward_era: 'RewardEra',
       expires_at_block: 'BlockNumber',


### PR DESCRIPTION
# Goal
The goal of this PR is to fix a flaky e2e test for `capacityRuntimeApi.listUnclaimedRewards`

# Discussion

- Remove redundant definitions in api-augment for Capacity
- Updated the test to not be dependent on starting just before an era