### PR TITLE
Make RewardEras zero-indexed

### DIFF
--- a/e2e/capacity/provider_boost.test.ts
+++ b/e2e/capacity/provider_boost.test.ts
@@ -7,10 +7,11 @@ import {
   CENTS,
   DOLLARS,
   createAndFundKeypair,
-  boostProvider,
+  boostProvider, stakeToProvider,
 } from '../scaffolding/helpers';
 
 const fundingSource = getFundingSource('capacity-provider-boost');
+const tokenMinStake: bigint = 1n * CENTS;
 
 describe('Capacity: provider_boost extrinsic', function () {
   const providerBalance = 2n * DOLLARS;
@@ -22,17 +23,18 @@ describe('Capacity: provider_boost extrinsic', function () {
     await assert.doesNotReject(boostProvider(fundingSource, booster, provider, 1n * DOLLARS));
   });
 
-  it('fails when staker is a Maximized Capacity staker', async function () {
+  it.only('fails when staker is a Maximized Capacity staker', async function () {
     const stakeKeys = createKeys('booster');
     const provider = await createMsaAndProvider(fundingSource, stakeKeys, 'Provider1', providerBalance);
-    await assert.rejects(boostProvider(fundingSource, stakeKeys, provider, 1n * DOLLARS), {name: "CannotChangeStakingType"});
+    await assert.doesNotReject(stakeToProvider(fundingSource, stakeKeys, provider, tokenMinStake));
+    await assert.rejects(boostProvider(fundingSource, stakeKeys, provider, tokenMinStake), {name: "CannotChangeStakingType"});
   });
 
   it("fails when staker doesn't have enough token", async function () {
     const stakeKeys = createKeys('booster');
     const provider = await createMsaAndProvider(fundingSource, stakeKeys, 'Provider1', providerBalance);
     const booster = await createAndFundKeypair(fundingSource, 1n * DOLLARS, 'booster');
-    await assert.rejects(boostProvider(booster, booster, provider, 1n * DOLLARS), {name: "InsufficientCapacityBalance"});
+    await assert.rejects(boostProvider(booster, booster, provider, 1n * DOLLARS), {name: "BalanceTooLowtoStake"});
   });
 
   it('staker can boost multiple times', async function () {

--- a/e2e/capacity/provider_boost.test.ts
+++ b/e2e/capacity/provider_boost.test.ts
@@ -23,7 +23,7 @@ describe('Capacity: provider_boost extrinsic', function () {
     await assert.doesNotReject(boostProvider(fundingSource, booster, provider, 1n * DOLLARS));
   });
 
-  it.only('fails when staker is a Maximized Capacity staker', async function () {
+  it('fails when staker is a Maximized Capacity staker', async function () {
     const stakeKeys = createKeys('booster');
     const provider = await createMsaAndProvider(fundingSource, stakeKeys, 'Provider1', providerBalance);
     await assert.doesNotReject(stakeToProvider(fundingSource, stakeKeys, provider, tokenMinStake));

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -2471,7 +2471,7 @@
     "node_modules/@frequency-chain/api-augment": {
       "version": "0.0.0",
       "resolved": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
-      "integrity": "sha512-7prkQiSHJ0aCa9vqR6g5HwVZ55rstu94m1FjQvJQO7MIt8BgSQYAsP0N1pc2CmtN0k72wYeGRV3+nLnWkfKG1w==",
+      "integrity": "sha512-c30YAG6cOgSQPYQFJ5MLPUNR1mn0y0QTxf5YauEtafALIOXodrVCBCd+63R10k1X+fYNEKiuqved60kCmAabcw==",
       "dependencies": {
         "@polkadot/api": "^12.2.3",
         "@polkadot/rpc-provider": "^12.2.3",

--- a/e2e/scaffolding/helpers.ts
+++ b/e2e/scaffolding/helpers.ts
@@ -447,8 +447,9 @@ export async function boostProvider(
 ): Promise<void> {
   const stakeOp = ExtrinsicHelper.providerBoost(keys, providerId, tokensToStake);
   const { target: stakeEvent } = await stakeOp.fundAndSend(source);
+  console.debug("stakeEvent: ", stakeEvent.toHuman());
   assert.notEqual(stakeEvent, undefined, 'stakeToProvider: should have returned Stake event');
-
+  console.debug("HERE");
   if (stakeEvent) {
     const stakedCapacity = stakeEvent.data.capacity;
 

--- a/e2e/scaffolding/helpers.ts
+++ b/e2e/scaffolding/helpers.ts
@@ -447,9 +447,7 @@ export async function boostProvider(
 ): Promise<void> {
   const stakeOp = ExtrinsicHelper.providerBoost(keys, providerId, tokensToStake);
   const { target: stakeEvent } = await stakeOp.fundAndSend(source);
-  console.debug("stakeEvent: ", stakeEvent.toHuman());
   assert.notEqual(stakeEvent, undefined, 'stakeToProvider: should have returned Stake event');
-  console.debug("HERE");
   if (stakeEvent) {
     const stakedCapacity = stakeEvent.data.capacity;
 

--- a/pallets/capacity/src/lib.rs
+++ b/pallets/capacity/src/lib.rs
@@ -268,24 +268,6 @@ pub mod pallet {
 	pub type ProviderBoostHistories<T: Config> =
 		StorageMap<_, Twox64Concat, T::AccountId, ProviderBoostHistory<T>>;
 
-	#[pallet::genesis_config]
-	pub struct GenesisConfig<T: Config> {
-		/// Phantom type
-		#[serde(skip)]
-		pub _config: PhantomData<T>,
-	}
-
-	#[pallet::genesis_build]
-	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
-		fn build(&self) {
-			CurrentEraInfo::<T>::set(RewardEraInfo {
-				era_index: 1u32.into(),
-				started_at: 0u32.into(),
-			});
-			CurrentEraProviderBoostTotal::<T>::set(0u32.into());
-		}
-	}
-
 	// Simple declaration of the `Pallet` type. It is placeholder we use to implement traits and
 	// method.
 	#[pallet::pallet]
@@ -1096,11 +1078,11 @@ impl<T: Config> Pallet<T> {
 		let max_history: u32 = T::ProviderBoostHistoryLimit::get();
 
 		let start_era = current_era_info.era_index.saturating_sub((max_history).into());
-		let end_era = current_era_info.era_index.saturating_sub(One::one());
+		let end_era = current_era_info.era_index.saturating_sub(One::one()); // stop at previous era
 
 		// start with how much was staked in the era before the earliest for which there are eligible rewards.
 		let mut previous_amount: BalanceOf<T> =
-			staking_history.get_amount_staked_for_era(&(start_era.saturating_sub(1u32.into())));
+			staking_history.get_amount_staked_for_era(&(start_era.saturating_sub(0u32.into())));
 
 		let mut unclaimed_rewards: BoundedVec<
 			UnclaimedRewardInfo<BalanceOf<T>, BlockNumberFor<T>>,

--- a/pallets/capacity/src/lib.rs
+++ b/pallets/capacity/src/lib.rs
@@ -1081,9 +1081,11 @@ impl<T: Config> Pallet<T> {
 		let end_era = current_era_info.era_index.saturating_sub(One::one()); // stop at previous era
 
 		// start with how much was staked in the era before the earliest for which there are eligible rewards.
-		let mut previous_amount: BalanceOf<T> =
-			staking_history.get_amount_staked_for_era(&(start_era.saturating_sub(0u32.into())));
-
+		let mut previous_amount: BalanceOf<T> = match start_era {
+			0 => 0u32.into(),
+			_ =>
+				staking_history.get_amount_staked_for_era(&(start_era.saturating_sub(1u32.into()))),
+		};
 		let mut unclaimed_rewards: BoundedVec<
 			UnclaimedRewardInfo<BalanceOf<T>, BlockNumberFor<T>>,
 			T::ProviderBoostHistoryLimit,

--- a/pallets/capacity/src/lib.rs
+++ b/pallets/capacity/src/lib.rs
@@ -1165,7 +1165,7 @@ impl<T: Config> Pallet<T> {
 		let history_limit: u32 = T::ProviderBoostHistoryLimit::get();
 		let chunk_len = T::RewardPoolChunkLength::get();
 		// Remove one because eras are 1 indexed
-		let era_u32: u32 = era.saturating_sub(One::one()).into();
+		let era_u32: u32 = era;
 
 		// Add one chunk so that we always have the full history limit in our chunks
 		let cycle: u32 = era_u32 % history_limit.saturating_add(chunk_len);

--- a/pallets/capacity/src/migration/provider_boost_init.rs
+++ b/pallets/capacity/src/migration/provider_boost_init.rs
@@ -14,12 +14,10 @@ impl<T: Config> OnRuntimeUpgrade for ProviderBoostInit<T> {
 	fn on_runtime_upgrade() -> Weight {
 		let current_era_info = CurrentEraInfo::<T>::get(); // 1r
 		if current_era_info.eq(&RewardEraInfo::default()) {
-			CurrentEraInfo::<T>::set(
-				RewardEraInfo {
-					era_index: 0u32.into(),
-					started_at: frame_system::Pallet::<T>::block_number(),
-				}
-			); // 1w
+			CurrentEraInfo::<T>::set(RewardEraInfo {
+				era_index: 0u32.into(),
+				started_at: frame_system::Pallet::<T>::block_number(),
+			}); // 1w
 			CurrentEraProviderBoostTotal::<T>::set(0u32.into()); // 1w
 			T::DbWeight::get().reads_writes(2, 1)
 		} else {

--- a/pallets/capacity/src/migration/provider_boost_init.rs
+++ b/pallets/capacity/src/migration/provider_boost_init.rs
@@ -4,7 +4,6 @@ use frame_support::{
 	traits::{Get, OnRuntimeUpgrade},
 };
 
-use common_primitives::capacity::RewardEra;
 #[cfg(feature = "try-runtime")]
 use sp_std::vec::Vec;
 
@@ -15,9 +14,12 @@ impl<T: Config> OnRuntimeUpgrade for ProviderBoostInit<T> {
 	fn on_runtime_upgrade() -> Weight {
 		let current_era_info = CurrentEraInfo::<T>::get(); // 1r
 		if current_era_info.eq(&RewardEraInfo::default()) {
-			let current_block = frame_system::Pallet::<T>::block_number(); // Whitelisted
-			let era_index: RewardEra = 1u32.into();
-			CurrentEraInfo::<T>::set(RewardEraInfo { era_index, started_at: current_block }); // 1w
+			CurrentEraInfo::<T>::set(
+				RewardEraInfo {
+					era_index: 0u32.into(),
+					started_at: frame_system::Pallet::<T>::block_number(),
+				}
+			); // 1w
 			CurrentEraProviderBoostTotal::<T>::set(0u32.into()); // 1w
 			T::DbWeight::get().reads_writes(2, 1)
 		} else {

--- a/pallets/capacity/src/tests/claim_staking_rewards_tests.rs
+++ b/pallets/capacity/src/tests/claim_staking_rewards_tests.rs
@@ -21,11 +21,11 @@ fn claim_staking_rewards_leaves_one_history_item_for_current_era() {
 
 		setup_provider(&account, &target, &amount, ProviderBoost);
 		run_to_block(31);
-		assert_eq!(CurrentEraInfo::<Test>::get().era_index, 4u32);
+		assert_eq!(CurrentEraInfo::<Test>::get().era_index, 3u32);
 
 		let current_history = ProviderBoostHistories::<Test>::get(account).unwrap();
 		assert_eq!(current_history.count(), 1usize);
-		let history_item = current_history.get_entry_for_era(&1u32).unwrap();
+		let history_item = current_history.get_entry_for_era(&0u32).unwrap();
 		assert_eq!(*history_item, amount);
 	})
 }
@@ -57,25 +57,25 @@ fn claim_staking_rewards_mints_and_transfers_expected_total() {
 
 		setup_provider(&account, &target, &amount, ProviderBoost);
 		run_to_block(31);
-		assert_eq!(CurrentEraInfo::<Test>::get().era_index, 4u32);
+		assert_eq!(CurrentEraInfo::<Test>::get().era_index, 3u32);
 		assert_ok!(Capacity::claim_staking_rewards(RuntimeOrigin::signed(account)));
 		System::assert_last_event(
 			Event::<Test>::ProviderBoostRewardClaimed { account, reward_amount: 8u64 }.into(),
 		);
 
-		// should have 2 era's worth of payouts: 4 each for eras 2, 3
+		// should have 2 era's worth of payouts: 4 each for eras 1, 2
 		assert_eq!(get_balance::<Test>(&account), 10_008u64);
 
 		// the reward value is unlocked
 		assert_transferable::<Test>(&account, 8u64);
 
-		run_to_block(51);
-		assert_eq!(CurrentEraInfo::<Test>::get().era_index, 6u32);
+		run_to_block(41);
+		assert_eq!(CurrentEraInfo::<Test>::get().era_index, 4u32);
 		assert_ok!(Capacity::claim_staking_rewards(RuntimeOrigin::signed(account)));
 		System::assert_last_event(
 			ProviderBoostRewardClaimed { account, reward_amount: 8u64 }.into(),
 		);
-		// should have 4 for eras 2-5
+		// should have 4 for eras 1-3
 		assert_eq!(get_balance::<Test>(&account), 10_016u64);
 		assert_transferable::<Test>(&account, 16u64);
 	})

--- a/pallets/capacity/src/tests/claim_staking_rewards_tests.rs
+++ b/pallets/capacity/src/tests/claim_staking_rewards_tests.rs
@@ -72,12 +72,13 @@ fn claim_staking_rewards_mints_and_transfers_expected_total() {
 		run_to_block(41);
 		assert_eq!(CurrentEraInfo::<Test>::get().era_index, 4u32);
 		assert_ok!(Capacity::claim_staking_rewards(RuntimeOrigin::signed(account)));
+		// rewards available for one more era
 		System::assert_last_event(
-			ProviderBoostRewardClaimed { account, reward_amount: 8u64 }.into(),
+			ProviderBoostRewardClaimed { account, reward_amount: 4u64 }.into(),
 		);
 		// should have 4 for eras 1-3
-		assert_eq!(get_balance::<Test>(&account), 10_016u64);
-		assert_transferable::<Test>(&account, 16u64);
+		assert_eq!(get_balance::<Test>(&account), 10_012u64);
+		assert_transferable::<Test>(&account, 12u64);
 	})
 }
 

--- a/pallets/capacity/src/tests/eras_tests.rs
+++ b/pallets/capacity/src/tests/eras_tests.rs
@@ -1,10 +1,10 @@
 use super::mock::*;
 use crate::{
 	tests::testing_utils::*, BalanceOf, CurrentEraInfo, CurrentEraProviderBoostTotal,
-	ProviderBoostRewardPools, RewardEraInfo,
+	ProviderBoostRewardPools, RewardEraInfo, Config
 };
 use common_primitives::{capacity::RewardEra, msa::MessageSourceId};
-use frame_support::assert_ok;
+use frame_support::{assert_ok, traits::Get};
 
 pub fn boost_provider_and_run_to_end_of_era(
 	staker: u64,
@@ -13,10 +13,14 @@ pub fn boost_provider_and_run_to_end_of_era(
 	era: u32,
 ) {
 	assert_ok!(Capacity::provider_boost(RuntimeOrigin::signed(staker), provider_msa, stake_amount));
-	let block_decade: u32 = (era * 10) + 1;
-	run_to_block(block_decade);
-	assert_eq!(CurrentEraProviderBoostTotal::<Test>::get(), stake_amount * (era as u64));
-	system_run_to_block(block_decade + 9);
+	// want to run to the first block of era so we get the on_initialize updates
+	let first_block_of_era: u32 = ((era+1u32) * 10) + 1;
+	run_to_block(first_block_of_era);
+	let expected_stake =  stake_amount * ( (era + 1u32) as u64);
+	assert_eq!(CurrentEraProviderBoostTotal::<Test>::get(), expected_stake);
+	// run to end of era.
+	let era_length: RewardEra = <Test as Config>::EraLength::get();
+	system_run_to_block(first_block_of_era + era_length - 1);
 }
 
 #[test]
@@ -29,7 +33,7 @@ fn start_new_era_if_needed_updates_era_info() {
 
 			let current_era_info = CurrentEraInfo::<Test>::get();
 
-			let expected_era = i + 1;
+			let expected_era = i;
 			assert_eq!(
 				current_era_info,
 				RewardEraInfo { era_index: expected_era, started_at: block_decade }
@@ -48,9 +52,9 @@ fn assert_chunk_is_full_and_has_earliest_era_total(
 	total: BalanceOf<Test>,
 ) {
 	let chunk = ProviderBoostRewardPools::<Test>::get(chunk_index).unwrap();
-	assert_eq!(chunk.is_full(), is_full, "{:?}", chunk);
-	assert_eq!(chunk.earliest_era(), Some(&era), "{:?}", chunk);
-	assert_eq!(chunk.total_for_era(&era), Some(&total), "{:?}", chunk);
+	assert_eq!(chunk.is_full(), is_full, "Chunk {:?} should be full: {:?}", chunk_index, chunk);
+	assert_eq!(chunk.earliest_era(), Some(&era), "Earliest era should be {:?}, {:?}", era, chunk);
+	assert_eq!(chunk.total_for_era(&era), Some(&total), "Chunk total should be {:?}, {:?}", total, chunk);
 }
 
 // gets the last (i.e. latest non-current) stored reward pool era, which is in chunk 0.
@@ -62,15 +66,17 @@ fn assert_last_era_total(era: RewardEra, total: BalanceOf<Test>) {
 	let chunk = chunk_opt.unwrap();
 	let (_earliest, latest) = chunk.era_range();
 	assert_eq!(latest, era);
-	assert_eq!(chunk.total_for_era(&era), Some(&total));
+	assert_eq!(chunk.total_for_era(&era), Some(&total), "Chunk total should be {:?}, {:?}", total, chunk);
 }
 
 fn assert_chunk_is_empty(chunk_index: u32) {
 	let chunk_opt = ProviderBoostRewardPools::<Test>::get(chunk_index);
 	if chunk_opt.is_some() {
-		assert!(chunk_opt.unwrap().earliest_era().is_none())
+		let chunk = chunk_opt.unwrap();
+		assert!(chunk.earliest_era().is_none(),
+				"Earliest era for chunk {:?} should be None but it is {:?}", chunk_index, chunk)
 	} else {
-		assert!(chunk_opt.is_none())
+		assert!(chunk_opt.is_none(), "Expected chunk {:?} to be empty, but it's not", chunk_index);
 	}
 }
 
@@ -85,49 +91,49 @@ fn start_new_era_if_needed_updates_reward_pool() {
 
 		register_provider(provider_msa, "Binky".to_string());
 
-		for i in [1u32, 2u32, 3u32] {
+		for i in 0u32..=2u32 {
 			boost_provider_and_run_to_end_of_era(staker, provider_msa, stake_amount, i);
 		}
 		// check that first chunk is filled correctly.
-		assert_chunk_is_full_and_has_earliest_era_total(0, true, 1, 100);
-		assert_chunk_is_empty(1);
-		assert_chunk_is_empty(2);
-		assert_last_era_total(3, 300);
+		assert_chunk_is_full_and_has_earliest_era_total(0, true, 0, 100);
+		for i in 1u32..=4u32 {
+			assert_chunk_is_empty(i);
+		}
 
-		for i in [4u32, 5u32, 6u32] {
+		for i in [3u32, 4u32, 5u32] {
 			boost_provider_and_run_to_end_of_era(staker, provider_msa, stake_amount, i);
 		}
 		// No change
-		assert_chunk_is_full_and_has_earliest_era_total(0, true, 1, 100);
+		assert_chunk_is_full_and_has_earliest_era_total(0, true, 0, 100);
 		// New Chunk
-		assert_chunk_is_full_and_has_earliest_era_total(1, true, 4, 400);
+		assert_chunk_is_full_and_has_earliest_era_total(1, true, 3, 400);
 		assert_chunk_is_empty(2);
-		assert_last_era_total(6, 600);
+		assert_last_era_total(5, 600);
 
-		for i in [7u32, 8u32, 9u32, 10u32, 11u32, 12u32, 13u32, 14u32, 15u32] {
+		for i in [6u32, 7u32, 8u32, 9u32, 10u32, 11u32, 12u32, 13u32, 14u32] {
 			boost_provider_and_run_to_end_of_era(staker, provider_msa, stake_amount, i);
 		}
 		// No changes
-		assert_chunk_is_full_and_has_earliest_era_total(0, true, 1, 100);
-		assert_chunk_is_full_and_has_earliest_era_total(1, true, 4, 400);
+		assert_chunk_is_full_and_has_earliest_era_total(0, true, 0, 100);
+		assert_chunk_is_full_and_has_earliest_era_total(1, true, 3, 400);
 		// New
-		assert_chunk_is_full_and_has_earliest_era_total(2, true, 7, 700);
-		assert_chunk_is_full_and_has_earliest_era_total(3, true, 10, 1000);
-		assert_chunk_is_full_and_has_earliest_era_total(4, true, 13, 1300);
+		assert_chunk_is_full_and_has_earliest_era_total(2, true, 6, 700);
+		assert_chunk_is_full_and_has_earliest_era_total(3, true, 9, 1000);
+		assert_chunk_is_full_and_has_earliest_era_total(4, true, 12, 1300);
 		assert_last_era_total(15, 1500);
 
 		// check that it all rolls over properly.
-		for i in [16u32, 17u32] {
+		for i in [15u32, 16u32] {
 			boost_provider_and_run_to_end_of_era(staker, provider_msa, stake_amount, i);
 		}
 		// No Changes
-		assert_chunk_is_full_and_has_earliest_era_total(1, true, 4, 400);
-		assert_chunk_is_full_and_has_earliest_era_total(2, true, 7, 700);
-		assert_chunk_is_full_and_has_earliest_era_total(3, true, 10, 1000);
-		assert_chunk_is_full_and_has_earliest_era_total(4, true, 13, 1300);
+		assert_chunk_is_full_and_has_earliest_era_total(1, true, 3, 400);
+		assert_chunk_is_full_and_has_earliest_era_total(2, true, 6, 700);
+		assert_chunk_is_full_and_has_earliest_era_total(3, true, 9, 1000);
+		assert_chunk_is_full_and_has_earliest_era_total(4, true, 12, 1300);
 		// New
-		assert_chunk_is_full_and_has_earliest_era_total(0, false, 16, 1600);
-		assert_last_era_total(17, 1700);
+		assert_chunk_is_full_and_has_earliest_era_total(0, false, 15, 1600);
+		assert_last_era_total(16, 1700);
 		// There shouldn't be a chunk 5 ever with this config
 		assert_chunk_is_empty(5);
 	});
@@ -136,12 +142,12 @@ fn start_new_era_if_needed_updates_reward_pool() {
 #[test]
 fn get_expiration_block_for_era_works() {
 	new_test_ext().execute_with(|| {
-		assert_eq!(CurrentEraInfo::<Test>::get().era_index, 1u32);
-		assert_eq!(Capacity::block_at_end_of_era(10u32), 100);
+		assert_eq!(CurrentEraInfo::<Test>::get().era_index, 0u32);
+		assert_eq!(Capacity::block_at_end_of_era(9u32), 100);
 
-		set_era_and_reward_pool(7, 61, 0);
-		assert_eq!(Capacity::block_at_end_of_era(7u32), 70);
-		assert_eq!(Capacity::block_at_end_of_era(10u32), 100);
+		set_era_and_reward_pool(7, 63, 0);
+		assert_eq!(Capacity::block_at_end_of_era(7u32), 72);
+		assert_eq!(Capacity::block_at_end_of_era(10u32), 102);
 
 		set_era_and_reward_pool(10, 91, 0);
 		assert_eq!(Capacity::block_at_end_of_era(10u32), 100);
@@ -166,27 +172,28 @@ fn get_chunk_index_for_era_works() {
 		// [16],[4,5,6],[7,8,9],[10,11,12],[13,14,15]
 		for test in {
 			vec![
+				TestCase { era: 0, expected: 0 },
 				TestCase { era: 1, expected: 0 },
 				TestCase { era: 2, expected: 0 },
-				TestCase { era: 3, expected: 0 },
+				TestCase { era: 3, expected: 1 },
 				TestCase { era: 4, expected: 1 },
 				TestCase { era: 5, expected: 1 },
-				TestCase { era: 6, expected: 1 },
+				TestCase { era: 6, expected: 2 },
 				TestCase { era: 7, expected: 2 },
 				TestCase { era: 8, expected: 2 },
-				TestCase { era: 9, expected: 2 },
+				TestCase { era: 9, expected: 3 },
 				TestCase { era: 10, expected: 3 },
 				TestCase { era: 11, expected: 3 },
-				TestCase { era: 12, expected: 3 },
-				TestCase { era: 13, expected: 4 }, // This is not wrong; there is an extra chunk to leave space for cycling
+				TestCase { era: 12, expected: 4 },// This is not wrong; there is an extra chunk to leave space for cycling
+				TestCase { era: 13, expected: 4 },
 				TestCase { era: 14, expected: 4 },
-				TestCase { era: 15, expected: 4 },
-				TestCase { era: 16, expected: 0 }, // So cycle restarts here, not at 13.
+				TestCase { era: 15, expected: 0 },// So cycle restarts here, not at 12.
+				TestCase { era: 16, expected: 0 },
 				TestCase { era: 17, expected: 0 },
-				TestCase { era: 18, expected: 0 },
+				TestCase { era: 18, expected: 1 },
 				TestCase { era: 22, expected: 2 },
 				TestCase { era: 55, expected: 3 },
-				TestCase { era: 999, expected: 2 },
+				TestCase { era: 998, expected: 2 },
 			]
 		} {
 			assert_eq!(Capacity::get_chunk_index_for_era(test.era), test.expected, "{:?}", test);

--- a/pallets/capacity/src/tests/mock.rs
+++ b/pallets/capacity/src/tests/mock.rs
@@ -236,7 +236,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	ext.execute_with(|| {
 		System::set_block_number(1);
 		initialize_reward_pool();
-		set_era_and_reward_pool(1, 1, 0);
+		set_era_and_reward_pool(0, 1, 0);
 	});
 	ext
 }

--- a/pallets/capacity/src/tests/provider_boost_history_tests.rs
+++ b/pallets/capacity/src/tests/provider_boost_history_tests.rs
@@ -34,7 +34,7 @@ fn multiple_provider_boosts_updates_history_correctly() {
 		// should update era 1 history
 		let mut history = ProviderBoostHistories::<Test>::get(staker).unwrap();
 		assert_eq!(history.count(), 1);
-		assert_eq!(history.get_entry_for_era(&1u32).unwrap(), &700u64);
+		assert_eq!(history.get_entry_for_era(&0u32).unwrap(), &700u64);
 
 		system_run_to_block(10);
 		run_to_block(11);
@@ -44,7 +44,7 @@ fn multiple_provider_boosts_updates_history_correctly() {
 		// should add an era 2 history
 		history = ProviderBoostHistories::<Test>::get(staker).unwrap();
 		assert_eq!(history.count(), 2);
-		assert_eq!(history.get_entry_for_era(&2u32).unwrap(), &900u64);
+		assert_eq!(history.get_entry_for_era(&1u32).unwrap(), &900u64);
 	})
 }
 

--- a/pallets/capacity/src/tests/reward_pool_tests.rs
+++ b/pallets/capacity/src/tests/reward_pool_tests.rs
@@ -1,9 +1,6 @@
 use crate::{
-	tests::{
-		mock::*,
-		testing_utils::{run_to_block, set_era_and_reward_pool},
-	},
-	BalanceOf, Config, CurrentEraInfo, ProviderBoostRewardPools, RewardPoolHistoryChunk,
+	tests::{mock::*, testing_utils::set_era_and_reward_pool},
+	BalanceOf, Config, ProviderBoostRewardPools, RewardPoolHistoryChunk,
 };
 use common_primitives::capacity::RewardEra;
 use frame_support::{assert_ok, traits::Get};

--- a/pallets/capacity/src/tests/reward_pool_tests.rs
+++ b/pallets/capacity/src/tests/reward_pool_tests.rs
@@ -1,13 +1,15 @@
 use crate::{
 	tests::{mock::*, testing_utils::set_era_and_reward_pool},
-	BalanceOf, Config, ProviderBoostRewardPools, RewardPoolHistoryChunk,
+	BalanceOf, Config, ProviderBoostRewardPools, RewardPoolHistoryChunk,CurrentEraInfo
 };
 use common_primitives::capacity::RewardEra;
 use frame_support::{assert_ok, traits::Get};
 use std::ops::Add;
+use crate::tests::testing_utils::{run_to_block};
 
-// Check eras_tests for how reward pool chunks are expected to be filled during
-// runtime.
+// Check eras_tests for how reward pool chunks are expected to be filled during runtime.
+
+// Fill up a reward pool history chunk by adding 100 in each new era from the starting value.
 fn fill_reward_pool_history_chunk(
 	chunk_index: u32,
 	starting_era: RewardEra,
@@ -61,17 +63,33 @@ fn get_total_stake_for_past_era_works_with_partly_filled_single_chunk() {
 		assert!(Capacity::get_total_stake_for_past_era(99, 3).is_err());
 	})
 }
+#[test]
+fn debugging_rphc_past_era() {
+	new_test_ext().execute_with(|| {
+		set_era_and_reward_pool(0, 1, 1000);
+		run_to_block(11);
+		assert_eq!(CurrentEraInfo::<Test>::get().era_index, 1u32);
+		assert_eq!(Capacity::get_total_stake_for_past_era(0, 1), Ok(1000));
+		run_to_block(51);
+		assert_eq!(CurrentEraInfo::<Test>::get().era_index, 5u32);
+		assert_eq!(Capacity::get_total_stake_for_past_era(0, 5), Ok(1000));
+		run_to_block(121);
+		assert_eq!(CurrentEraInfo::<Test>::get().era_index, 12u32);
+		assert_eq!(Capacity::get_total_stake_for_past_era(0, 5), Ok(1000));
+		run_to_block(121);
+	})
+}
 
 #[test]
 fn get_total_stake_for_past_era_works_with_1_full_chunk() {
 	new_test_ext().execute_with(|| {
 		System::set_block_number(52);
 		set_era_and_reward_pool(6, 51, 1000);
-		fill_reward_pool_history_chunk(0, 1, 3, 100); // eras 1-3
-		fill_reward_pool_history_chunk(1, 4, 2, 400); // eras 4,5
-		for i in 3u32..=5u32 {
+		fill_reward_pool_history_chunk(0, 0, 3, 0); // eras 1-3
+		fill_reward_pool_history_chunk(1, 3, 2, 300); // eras 4,5
+		for i in 2u32..=4u32 {
 			let expected_total: BalanceOf<Test> = (i * 100u32).into();
-			let actual = Capacity::get_total_stake_for_past_era(i, 6);
+			let actual = Capacity::get_total_stake_for_past_era(i, 5);
 			assert_eq!(actual, Ok(expected_total));
 		}
 		assert!(Capacity::get_total_stake_for_past_era(6, 6).is_err());
@@ -82,15 +100,15 @@ fn get_total_stake_for_past_era_works_with_1_full_chunk() {
 fn get_total_stake_for_past_era_works_with_2_full_chunks() {
 	new_test_ext().execute_with(|| {
 		System::set_block_number(72);
-		set_era_and_reward_pool(8, 71, 1000);
-		fill_reward_pool_history_chunk(0, 1, 3, 100);
-		fill_reward_pool_history_chunk(1, 4, 3, 400);
-		fill_reward_pool_history_chunk(2, 7, 1, 700);
-		for i in 1u32..=7u32 {
+		set_era_and_reward_pool(7, 71, 1000);
+		fill_reward_pool_history_chunk(0, 0, 3, 0);
+		fill_reward_pool_history_chunk(1, 3, 3, 300);
+		fill_reward_pool_history_chunk(2, 6, 1, 600);
+		for i in 0u32..=6u32 {
 			let expected_total: BalanceOf<Test> = (i * 100u32).into();
-			assert_eq!(Capacity::get_total_stake_for_past_era(i, 8), Ok(expected_total));
+			assert_eq!(Capacity::get_total_stake_for_past_era(i, 7), Ok(expected_total));
 		}
-		assert!(Capacity::get_total_stake_for_past_era(8, 8).is_err());
+		assert!(Capacity::get_total_stake_for_past_era(7, 7).is_err());
 	})
 }
 
@@ -99,17 +117,17 @@ fn get_total_stake_for_past_era_works_with_full_reward_pool() {
 	new_test_ext().execute_with(|| {
 		System::set_block_number(121);
 		let history_limit: u32 = <Test as Config>::ProviderBoostHistoryLimit::get();
-		set_era_and_reward_pool(13, 121, (2000u32).into());
+		set_era_and_reward_pool(12, 121, (2000u32).into());
 
-		fill_reward_pool_history_chunk(0, 1, 3, 101);
-		fill_reward_pool_history_chunk(1, 4, 3, 401);
-		fill_reward_pool_history_chunk(2, 7, 3, 701);
-		fill_reward_pool_history_chunk(3, 10, 3, 1001);
+		fill_reward_pool_history_chunk(0, 0, 3, 1);
+		fill_reward_pool_history_chunk(1, 3, 3, 301);
+		fill_reward_pool_history_chunk(2, 6, 3, 601);
+		fill_reward_pool_history_chunk(3, 9, 3, 901);
 
-		(1u32..=history_limit).for_each(|era| {
+		(0u32..history_limit).for_each(|era| {
 			let expected_total: BalanceOf<Test> = ((era * 100u32) + 1u32).into();
-			assert_eq!(Capacity::get_total_stake_for_past_era(era, 13), Ok(expected_total));
+			assert_eq!(Capacity::get_total_stake_for_past_era(era, 12), Ok(expected_total));
 		});
-		assert!(Capacity::get_total_stake_for_past_era(13, 13).is_err());
+		assert!(Capacity::get_total_stake_for_past_era(12, 12).is_err());
 	})
 }

--- a/pallets/capacity/src/tests/reward_pool_tests.rs
+++ b/pallets/capacity/src/tests/reward_pool_tests.rs
@@ -65,22 +65,6 @@ fn get_total_stake_for_past_era_works_with_partly_filled_single_chunk() {
 		assert!(Capacity::get_total_stake_for_past_era(99, 3).is_err());
 	})
 }
-#[test]
-fn debugging_rphc_past_era() {
-	new_test_ext().execute_with(|| {
-		set_era_and_reward_pool(0, 1, 1000);
-		run_to_block(11);
-		assert_eq!(CurrentEraInfo::<Test>::get().era_index, 1u32);
-		assert_eq!(Capacity::get_total_stake_for_past_era(0, 1), Ok(1000));
-		run_to_block(51);
-		assert_eq!(CurrentEraInfo::<Test>::get().era_index, 5u32);
-		assert_eq!(Capacity::get_total_stake_for_past_era(0, 5), Ok(1000));
-		run_to_block(121);
-		assert_eq!(CurrentEraInfo::<Test>::get().era_index, 12u32);
-		assert_eq!(Capacity::get_total_stake_for_past_era(0, 5), Ok(1000));
-		run_to_block(121);
-	})
-}
 
 #[test]
 fn get_total_stake_for_past_era_works_with_1_full_chunk() {

--- a/pallets/capacity/src/tests/reward_pool_tests.rs
+++ b/pallets/capacity/src/tests/reward_pool_tests.rs
@@ -1,11 +1,13 @@
 use crate::{
-	tests::{mock::*, testing_utils::set_era_and_reward_pool},
-	BalanceOf, Config, ProviderBoostRewardPools, RewardPoolHistoryChunk,CurrentEraInfo
+	tests::{
+		mock::*,
+		testing_utils::{run_to_block, set_era_and_reward_pool},
+	},
+	BalanceOf, Config, CurrentEraInfo, ProviderBoostRewardPools, RewardPoolHistoryChunk,
 };
 use common_primitives::capacity::RewardEra;
 use frame_support::{assert_ok, traits::Get};
 use std::ops::Add;
-use crate::tests::testing_utils::{run_to_block};
 
 // Check eras_tests for how reward pool chunks are expected to be filled during runtime.
 

--- a/pallets/capacity/src/tests/rewards_provider_tests.rs
+++ b/pallets/capacity/src/tests/rewards_provider_tests.rs
@@ -12,7 +12,6 @@ use common_primitives::msa::MessageSourceId;
 use frame_support::{assert_ok, traits::Len};
 use frame_system::pallet_prelude::BlockNumberFor;
 use sp_core::Get;
-use common_primitives::capacity::RewardEra;
 
 // This tests Capacity implementation of the trait, but uses the mock's constants,
 // to ensure that it's correctly specified in the pallet.
@@ -113,7 +112,7 @@ fn list_unclaimed_rewards_has_eligible_rewards() {
 		run_to_block(31);
 		assert_ok!(Capacity::provider_boost(RuntimeOrigin::signed(account), target, amount));
 
-		run_to_block(51);
+		run_to_block(51); // era 5
 		assert_eq!(CurrentEraInfo::<Test>::get().era_index, 5u32);
 		assert_eq!(CurrentEraInfo::<Test>::get().started_at, 51u32);
 
@@ -157,25 +156,26 @@ fn list_unclaimed_rewards_has_eligible_rewards() {
 				eligible_amount: 3_000,
 				earned_amount: 11,
 			},
-		].to_vec();
+		]
+		.to_vec();
 		for i in 0..expected_info.len() {
 			assert_eq!(rewards.get(i).unwrap(), &expected_info[i]);
 		}
 
-		run_to_block(131);
+		run_to_block(141); // current era = 14
 		let rewards = Capacity::list_unclaimed_rewards(&account).unwrap();
 		let max_history: u32 = <Test as Config>::ProviderBoostHistoryLimit::get();
-		// the earliest era should no longer be stored.
+		// the earliest eras, 0 and 1, should no longer be stored.
 		assert_eq!(rewards.len(), max_history as usize);
-		assert_eq!(rewards.get(0).unwrap().reward_era, 1u32);
+		assert_eq!(rewards.get(0).unwrap().reward_era, 2u32);
 
-		// there was no change in stake, so the eligible and earned amounts should be the same as in
-		// reward era 5.
+		// there was no change in stake, so the eligible and earned amounts
+		// for era 13 should be the same as in reward era 5.
 		assert_eq!(
 			rewards.get((max_history - 1) as usize).unwrap(),
 			&UnclaimedRewardInfo {
 				reward_era: 13u32,
-				expires_at_block: 250,
+				expires_at_block: 260,
 				staked_amount: 3_000,
 				eligible_amount: 3_000,
 				earned_amount: 11,
@@ -184,7 +184,8 @@ fn list_unclaimed_rewards_has_eligible_rewards() {
 	})
 }
 
-// check that if an account boosted and then let it run for more than the number
+// "Set and forget" test.
+// Check that if an account boosted and then let it run for more than the number
 // of  history retention eras, eligible rewards are correct.
 #[test]
 fn list_unclaimed_rewards_returns_correctly_for_old_single_boost() {
@@ -199,32 +200,79 @@ fn list_unclaimed_rewards_returns_correctly_for_old_single_boost() {
 		setup_provider(&account, &target, &amount, ProviderBoost);
 		assert!(!Capacity::has_unclaimed_rewards(&account));
 
-		run_to_block(131);
+		run_to_block(131); // era 13
 		assert_eq!(CurrentEraInfo::<Test>::get().era_index, 13u32);
 		assert_eq!(CurrentEraInfo::<Test>::get().started_at, 131u32);
 
 		let boost_history = ProviderBoostHistories::<Test>::get(account).unwrap();
-		let zero_era: RewardEra = 0;
-		assert!(boost_history.get_entry_for_era(&zero_era).is_some());
+		assert!(boost_history.get_entry_for_era(&0u32).is_some());
 
 		let rewards = Capacity::list_unclaimed_rewards(&account).unwrap();
 
 		let max_history: u32 = <Test as Config>::ProviderBoostHistoryLimit::get();
 		assert_eq!(rewards.len(), max_history as usize);
 
-		// the earliest era should no longer be stored.
-		for i in 0u32..max_history {
-			let era = i + 1u32;
+		// the earliest era should not be returned.
+		assert_eq!(rewards.get(0).unwrap().reward_era, 1u32);
+
+		for era in 1u32..=max_history {
+			let expires_at_era = era.saturating_add(max_history.into());
+			let expires_at_block = Capacity::block_at_end_of_era(expires_at_era);
 			let expected_info: UnclaimedRewardInfo<BalanceOf<Test>, BlockNumberFor<Test>> =
 				UnclaimedRewardInfo {
-					reward_era: era.into(),
-					expires_at_block: (era * 10u32 + 120u32).into(),
+					reward_era: era,
+					expires_at_block,
 					staked_amount: 1000,
 					eligible_amount: 1000,
 					earned_amount: 4,
 				};
-			assert_eq!(rewards.get(i as usize).unwrap(), &expected_info);
+			let era_index: usize = (era - 1u32) as usize;
+			assert_eq!(rewards.get(era_index).unwrap(), &expected_info);
 		}
+	})
+}
+
+// this is to check that our 0-indexed era + when a Current Era starts at something besides one,
+// that the calculations are still correct
+#[test]
+fn list_unclaimed_rewards_current_era_starts_at_later_block_works() {
+	new_test_ext().execute_with(|| {
+		let account = 10_000u64;
+		let target: MessageSourceId = 10;
+		let amount = 1000u64;
+
+		System::set_block_number(9900);
+		set_era_and_reward_pool(0, 9898, 10_000);
+		setup_provider(&account, &target, &amount, ProviderBoost);
+
+		run_to_block(9910); // middle of era 1
+		assert_eq!(CurrentEraInfo::<Test>::get().era_index, 1u32);
+		assert_eq!(CurrentEraInfo::<Test>::get().started_at, 9908u32);
+
+		run_to_block(9920); // middle of era 2, now some rewards can be claimed
+		assert_eq!(CurrentEraInfo::<Test>::get().era_index, 2u32);
+		assert_eq!(CurrentEraInfo::<Test>::get().started_at, 9918u32);
+
+		let expected_info_era_0: UnclaimedRewardInfo<BalanceOf<Test>, BlockNumberFor<Test>> =
+			UnclaimedRewardInfo {
+				reward_era: 0,
+				expires_at_block: 9898u32 + 129u32,
+				staked_amount: 1000,
+				eligible_amount: 0,
+				earned_amount: 0,
+			};
+		let expected_info_era_1: UnclaimedRewardInfo<BalanceOf<Test>, BlockNumberFor<Test>> =
+			UnclaimedRewardInfo {
+				reward_era: 1,
+				expires_at_block: 9908u32 + 129u32,
+				staked_amount: 1000,
+				eligible_amount: 1000,
+				earned_amount: 4,
+			};
+
+		let rewards = Capacity::list_unclaimed_rewards(&account).unwrap();
+		assert_eq!(rewards.get(0).unwrap(), &expected_info_era_0);
+		assert_eq!(rewards.get(1).unwrap(), &expected_info_era_1);
 	})
 }
 

--- a/pallets/capacity/src/tests/testing_utils.rs
+++ b/pallets/capacity/src/tests/testing_utils.rs
@@ -14,7 +14,13 @@ pub fn capacity_events() -> Vec<Event<Test>> {
 	let result = System::events()
 		.into_iter()
 		.map(|r| r.event)
-		.filter_map(|e| if let RuntimeEvent::Capacity(inner) = e { Some(inner) } else { None })
+		.filter_map(|e| if let RuntimeEvent::Capacity(inner) = e {
+			log::warn!("inner: {:?}", inner);
+			Some(inner)
+		} else {
+			log::warn!("nothing");
+			None
+		})
 		.collect::<Vec<_>>();
 
 	System::reset_events();

--- a/pallets/capacity/src/tests/testing_utils.rs
+++ b/pallets/capacity/src/tests/testing_utils.rs
@@ -14,12 +14,14 @@ pub fn capacity_events() -> Vec<Event<Test>> {
 	let result = System::events()
 		.into_iter()
 		.map(|r| r.event)
-		.filter_map(|e| if let RuntimeEvent::Capacity(inner) = e {
-			log::warn!("inner: {:?}", inner);
-			Some(inner)
-		} else {
-			log::warn!("nothing");
-			None
+		.filter_map(|e| {
+			if let RuntimeEvent::Capacity(inner) = e {
+				log::warn!("inner: {:?}", inner);
+				Some(inner)
+			} else {
+				log::warn!("nothing");
+				None
+			}
 		})
 		.collect::<Vec<_>>();
 

--- a/pallets/capacity/src/tests/unstaking_tests.rs
+++ b/pallets/capacity/src/tests/unstaking_tests.rs
@@ -366,17 +366,27 @@ fn unstake_by_a_booster_updates_provider_boost_history_with_correct_amount() {
 		register_provider(target1, String::from("Test Target"));
 
 		assert_ok!(Capacity::provider_boost(RuntimeOrigin::signed(staker), target1, 1_000));
-		let pbh = ProviderBoostHistories::<Test>::get(staker).unwrap();
+		let mut pbh = ProviderBoostHistories::<Test>::get(staker).unwrap();
 		assert_eq!(pbh.count(), 1);
 
 		// If unstaking in the next era, this should add a new staking history entry.
-		system_run_to_block(9);
-		run_to_block(41);
+		system_run_to_block(10); // last block of era 0
+		run_to_block(41); // beginning of era 4
 		assert_ok!(Capacity::claim_staking_rewards(RuntimeOrigin::signed(staker)));
+		pbh = ProviderBoostHistories::<Test>::get(staker).unwrap();
+		assert_eq!(pbh.count(), 1);
+
+		// This adds a new history item for the unstake, in current era, 4
 		assert_ok!(Capacity::unstake(RuntimeOrigin::signed(staker), target1, 400u64));
 
-		assert_eq!(get_balance::<Test>(&staker), 10_016u64);
-		assert_transferable::<Test>(&staker, 16u64);
+		// earned 4 in rewards for eras 3,2,1
+		assert_eq!(get_balance::<Test>(&staker), 10_012u64);
+		assert_transferable::<Test>(&staker, 12u64);
+
+		pbh = ProviderBoostHistories::<Test>::get(staker).unwrap();
+		assert_eq!(pbh.count(), 2);
+		let entry = pbh.get_entry_for_era(&4u32.into()).unwrap();
+		assert_eq!(entry, &600u64);
 	})
 }
 
@@ -387,35 +397,21 @@ fn unstake_all_by_booster_reaps_boost_history() {
 		let target1 = 1;
 		register_provider(target1, String::from("Test Target"));
 
+		// Era 0, block 1.
 		assert_ok!(Capacity::provider_boost(RuntimeOrigin::signed(staker), target1, 1_000));
 		let pbh = ProviderBoostHistories::<Test>::get(staker).unwrap();
 		assert_eq!(pbh.count(), 1);
 
 		// If unstaking in the next era, this should add a new staking history entry.
-		system_run_to_block(10);
-		run_to_block(41);
+		system_run_to_block(10); // last block of era 0
+		run_to_block(41); // First block of Era 4.
 		assert_ok!(Capacity::claim_staking_rewards(RuntimeOrigin::signed(staker)));
 		assert_ok!(Capacity::unstake(RuntimeOrigin::signed(staker), target1, 1_000));
 		assert!(ProviderBoostHistories::<Test>::get(staker).is_none());
-		assert_eq!(get_balance::<Test>(&staker), 10_016u64);
-		assert_transferable::<Test>(&staker, 16u64);
+		// earn 4 each for 3 past eras, 3,2,1
+		assert_eq!(get_balance::<Test>(&staker), 10_012u64);
+		assert_transferable::<Test>(&staker, 12u64);
 	})
-}
-
-#[test]
-fn unstake_all_if_no_unclaimed_rewards_removes_provider_boost_history() {
-	new_test_ext().execute_with(|| {
-		let account = 10_000u64;
-		let target: MessageSourceId = 10;
-		let amount = 1_000u64;
-
-		// staking 1k as of block 1, era 9
-		setup_provider(&account, &target, &amount, ProviderBoost);
-		assert!(ProviderBoostHistories::<Test>::get(account).is_some());
-		run_to_block(10);
-		assert_ok!(Capacity::unstake(RuntimeOrigin::signed(account), target, amount));
-		assert!(ProviderBoostHistories::<Test>::get(account).is_none());
-	});
 }
 
 #[test]
@@ -504,4 +500,3 @@ fn unstake_fails_if_provider_boosted_and_have_unclaimed_rewards() {
 		);
 	})
 }
-


### PR DESCRIPTION
# Goal
Reward eras were 1-indexed but this made things too confusing.

# Checklist
- [x] Unit Tests added and updated?
- [x] e2e Tests <del>added</del> updated?
