### PR TITLE
Standardize rust docs args and use of `RUSTC_BOOTSTRAP`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,9 +348,7 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Build Docs
         run: |
-          rustup target add wasm32-unknown-unknown --toolchain nightly-2024-08-01
-          rustup component add rust-src --toolchain nightly-2024-08-01
-          RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo +nightly-2024-08-01 doc --no-deps --workspace --features frequency
+          RUSTC_BOOTSTRAP=1 RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo doc --no-deps --workspace --features frequency
       - name: Fix file permissions
         shell: sh
         run: |

--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -236,15 +236,9 @@ jobs:
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
-      - name: Install Nightly Toolchain
-        run: rustup toolchain install nightly-2024-08-01
-      - name: Add Required Components
-        run: |
-          rustup target add wasm32-unknown-unknown --toolchain nightly-2024-08-01
-          rustup component add rust-src --toolchain nightly-2024-08-01
       - name: Build Docs
         run: |
-          RUSTDOCFLAGS="--enable-index-page --check -Zunstable-options" cargo +nightly-2024-08-01 doc --no-deps --features frequency
+          RUSTC_BOOTSTRAP=1 RUSTDOCFLAGS="--enable-index-page --check -Zunstable-options" cargo doc --no-deps --workspace --features frequency
 
   verify-rust-packages-and-deps:
     needs: changes

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ benchmarks-capacity:
 
 .PHONY: docs
 docs:
-	RUSTC_BOOTSTRAP=1 RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo doc --no-deps --features frequency
+	RUSTC_BOOTSTRAP=1 RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo doc --no-deps --workspace --features frequency
 
 # Cleans unused docker resources and artifacts
 .PHONY: docs


### PR DESCRIPTION
# Goal
The goal of this PR is to fix an issue with the last RC release attempt: https://github.com/frequency-chain/frequency/actions/runs/10324779461

# Discussion

- `RUSTC_BOOTSTRAP` turns "stable" rust into "nightly"
- We were using this before in places, but not consistently across all the workflows
- This correctly updates everything to use it and all to use the consistent parameters

## Verify
Locally run the `make docs` or `RUSTC_BOOTSTRAP=1 RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo doc --no-deps --workspace --features frequency` command