### PR TITLE
docker: add health check

### DIFF
--- a/docker/parachain-node.dockerfile
+++ b/docker/parachain-node.dockerfile
@@ -37,5 +37,9 @@ VOLUME ["/chain-data"]
 
 ENTRYPOINT ["/frequency/frequency"]
 
+HEALTHCHECK --interval=300s --timeout=75s --start-period=30s --retries=3 \
+	CMD ["./scripts/healthcheck.sh"]
+
+
 # Params which can be overriden from CLI
 # CMD ["", "", ...]

--- a/docker/standalone-node.dockerfile
+++ b/docker/standalone-node.dockerfile
@@ -38,3 +38,6 @@ EXPOSE 9944
 VOLUME ["/data"]
 
 ENTRYPOINT [ "/frequency/frequency-start.sh" ]
+
+HEALTHCHECK --interval=300s --timeout=75s --start-period=30s --retries=3 \
+	CMD ["./scripts/healthcheck.sh"]


### PR DESCRIPTION
# Goal
The goal of this PR is to add health check to docker images

Closes #1390
# Discussion
- Using the already existed script written by Puneet
- another alternative is to use something like the following
```bash
HEALTHCHECK --interval=300s --timeout=75s --start-period=30s --retries=3 \
  CMD curl -f http://localhost:9944/health || exit 1
```

