### PR TITLE
Bug Fix: Schema Runtime API typo

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -13,9 +13,9 @@
         "@frequency-chain/api-augment": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
         "@helia/unixfs": "^3.0.7",
         "@noble/curves": "^1.6.0",
-        "@polkadot-api/merkleize-metadata": "^1.1.2",
-        "@polkadot/api": "13.1.1",
-        "@polkadot/types": "13.1.1",
+        "@polkadot-api/merkleize-metadata": "^1.1.3",
+        "@polkadot/api": "13.2.1",
+        "@polkadot/types": "13.2.1",
         "@polkadot/util": "13.1.1",
         "helia": "^4.2.6",
         "multiformats": "^13.3.0",
@@ -23,10 +23,10 @@
         "workerpool": "^9.1.3"
       },
       "devDependencies": {
-        "@eslint/js": "^9.10.0",
+        "@eslint/js": "^9.11.1",
         "@types/mocha": "^10.0.8",
         "@types/workerpool": "^6.4.7",
-        "eslint": "^9.10.0",
+        "eslint": "^9.11.1",
         "eslint-plugin-mocha": "^10.5.0",
         "globals": "^15.9.0",
         "mocha": "^10.7.3",
@@ -35,7 +35,7 @@
         "sinon": "^19.0.2",
         "tsx": "^4.19.1",
         "typescript": "^5.6.2",
-        "typescript-eslint": "^8.6.0"
+        "typescript-eslint": "^8.7.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2265,6 +2265,15 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/core": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.6.0.tgz",
+      "integrity": "sha512-8I2Q8ykA4J0x0o7cg67FPVnehcqWTBehu/lmY+bolPFHGjh49YzGBMXTvpqVgEbBdvNCSxj6iFgiIyHzf03lzg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "3.1.0",
       "dev": true,
@@ -2299,9 +2308,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.10.0.tgz",
-      "integrity": "sha512-fuXtbiP5GWIn8Fz+LWoOMVf/Jxm+aajZYkhi6CuEm4SxymFM+eUWzbO9qXT+L0iCkL5+KGYMCSGxo686H19S1g==",
+      "version": "9.11.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.11.1.tgz",
+      "integrity": "sha512-/qu+TWz8WwPWc7/HcIJKi+c+MOm46GdVaSlTTQcaqaL53+GsoA6MxWp5PtTx48qbSP7ylM1Kn7nhvkugfJvRSA==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2317,9 +2326,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.1.0.tgz",
-      "integrity": "sha512-autAXT203ixhqei9xt+qkYOvY8l6LAFIdT2UXc/RPNeUVfqRF1BV94GTJyVPFKT8nFM6MyVJhjLj9E8JWvf5zQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
+      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
       "dev": true,
       "dependencies": {
         "levn": "^0.4.1"
@@ -2331,7 +2340,7 @@
     "node_modules/@frequency-chain/api-augment": {
       "version": "0.0.0",
       "resolved": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
-      "integrity": "sha512-Bc9kCev2AW9vH67Xon3NhESwe0wlz0c49mbsK9n2/FkS39VDzwmV/ywAX+3Me1E9gndH7yHZN9hE8I8BoHP5gg==",
+      "integrity": "sha512-nVZdWEOnNX/uvs4ckzhlmUv+50DrESyiGjtUQ3TnU6llQ33ejffjPikSYLtxuu1W4r6NS9QrTm1MtIqZ3ZOpYQ==",
       "dependencies": {
         "@polkadot/api": "^13.1.1",
         "@polkadot/rpc-provider": "^13.1.1",
@@ -3273,18 +3282,39 @@
       "optional": true
     },
     "node_modules/@polkadot-api/merkleize-metadata": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.1.2.tgz",
-      "integrity": "sha512-CzCwEUZaoshYKBPYI3lmOY+V3SEEZmErVrmRL50+Axlrs+wHxeu4fL/E3DIhdM1kKndnCazRnlB3oiiJ95AhxA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.1.3.tgz",
+      "integrity": "sha512-wgdm1tpAEFJ+vrDnCYZ4MA+3Dky0PItpUAnLmGfZqunR09WsKPcPJNLCD1ft2hSbQu9YrebqGmYJvwUIMO07MQ==",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.6.2",
+        "@polkadot-api/metadata-builders": "0.7.0",
+        "@polkadot-api/substrate-bindings": "0.8.0",
         "@polkadot-api/utils": "0.1.1"
       }
     },
+    "node_modules/@polkadot-api/merkleize-metadata/node_modules/@polkadot-api/metadata-builders": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.7.0.tgz",
+      "integrity": "sha512-TYbcgVz3f8fTn3lddT3NPvKA4/ELT3GifxMFSTXH4rennzx63yN1yhQHsbEOCW315LVL1gBQU0T7db3s3Dj1+g==",
+      "dependencies": {
+        "@polkadot-api/substrate-bindings": "0.7.0",
+        "@polkadot-api/utils": "0.1.1"
+      }
+    },
+    "node_modules/@polkadot-api/merkleize-metadata/node_modules/@polkadot-api/metadata-builders/node_modules/@polkadot-api/substrate-bindings": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.7.0.tgz",
+      "integrity": "sha512-cTzrPUAV+/iC2fa3JEGBilnZXttHS87PeaWTWGL/4hP/cXL+Xz9EAjJwGrp7MhwnSgAVBMD2l/ZoQvI4Bbm5jw==",
+      "dependencies": {
+        "@noble/hashes": "^1.4.0",
+        "@polkadot-api/utils": "0.1.1",
+        "@scure/base": "^1.1.7",
+        "scale-ts": "^1.6.0"
+      }
+    },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.6.2.tgz",
-      "integrity": "sha512-47XEbXeR2bL/3wsTGcCPFGoBkv2p1OYObr80JC7INizZ+qsvNokzziEmrKNXUPW66RqHmbpbYaNFF45JSNbPlQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.8.0.tgz",
+      "integrity": "sha512-nHj0tUIlrvm3tW8tSG7uvv4QBhfgjcwyNRFWdKQQ77gx83mfLdaBBrz9e2rPggwkWbptDZe2+IXE20OFF/G79w==",
       "dependencies": {
         "@noble/hashes": "^1.4.0",
         "@polkadot-api/utils": "0.1.1",
@@ -3351,22 +3381,22 @@
       "optional": true
     },
     "node_modules/@polkadot/api": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-13.1.1.tgz",
-      "integrity": "sha512-s4BTMKcf/3YoU14C0GmRC9APQTilNR/kNprRrfP1S+6umwsNoSuFXSZhaUWUovVlNWw7v7dca8NbFDSTjkoS4w==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-13.2.1.tgz",
+      "integrity": "sha512-QvgKD3/q6KIU3ZuNYFJUNc6B8bGBoqeMF+iaPxJn3Twhh4iVD5XIymD5fVszSqiL1uPXMhzcWecjwE8rDidBoQ==",
       "dependencies": {
-        "@polkadot/api-augment": "13.1.1",
-        "@polkadot/api-base": "13.1.1",
-        "@polkadot/api-derive": "13.1.1",
+        "@polkadot/api-augment": "13.2.1",
+        "@polkadot/api-base": "13.2.1",
+        "@polkadot/api-derive": "13.2.1",
         "@polkadot/keyring": "^13.1.1",
-        "@polkadot/rpc-augment": "13.1.1",
-        "@polkadot/rpc-core": "13.1.1",
-        "@polkadot/rpc-provider": "13.1.1",
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-augment": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
-        "@polkadot/types-create": "13.1.1",
-        "@polkadot/types-known": "13.1.1",
+        "@polkadot/rpc-augment": "13.2.1",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/rpc-provider": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-augment": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/types-create": "13.2.1",
+        "@polkadot/types-known": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "@polkadot/util-crypto": "^13.1.1",
         "eventemitter3": "^5.0.1",
@@ -3378,15 +3408,15 @@
       }
     },
     "node_modules/@polkadot/api-augment": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-13.1.1.tgz",
-      "integrity": "sha512-QWqw2zWpEEyP2s220b6rv0iq44XwhqQabicpGzCeMPAEJOnvzGjZMVD95o2C3oOq1FR025wQ1CU+4la2P4djNw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-13.2.1.tgz",
+      "integrity": "sha512-NTkI+/Hm48eWc/4Ojh/5elxnjnow5ptXK97IZdkWAe7mWi9hJR05Uq5lGt/T/57E9LSRWEuYje8cIDS3jbbAAw==",
       "dependencies": {
-        "@polkadot/api-base": "13.1.1",
-        "@polkadot/rpc-augment": "13.1.1",
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-augment": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
+        "@polkadot/api-base": "13.2.1",
+        "@polkadot/rpc-augment": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-augment": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "tslib": "^2.7.0"
       },
@@ -3395,12 +3425,12 @@
       }
     },
     "node_modules/@polkadot/api-base": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-13.1.1.tgz",
-      "integrity": "sha512-VEIOit6oTkOUi3CRUD1c6b/QF3cP0J1XxyMJR5q1/58fgTeUBjREmIyDgZzoXNX5ZK/9VD6pzqoWnKMeJGV5dA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-13.2.1.tgz",
+      "integrity": "sha512-00twdIjTjzdYNdU19i2YKLoWBmf2Yr6b3qrvqIVScHipUkKMbfFBgoPRB5FtcviBbEvLurgfyzHklwnrbWo8GQ==",
       "dependencies": {
-        "@polkadot/rpc-core": "13.1.1",
-        "@polkadot/types": "13.1.1",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/types": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "rxjs": "^7.8.1",
         "tslib": "^2.7.0"
@@ -3410,16 +3440,16 @@
       }
     },
     "node_modules/@polkadot/api-derive": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-13.1.1.tgz",
-      "integrity": "sha512-Avj4iSZlXXAPEhwnVAA0ZczW1HsgYYIpJFeC6Em3FhpDl4GLxS/UqwpGRhr97Ibqj6Ukv0dJ755xljyXkXiP+A==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-13.2.1.tgz",
+      "integrity": "sha512-npxvS0kYcSFqmYv2G8QKWAJwFhIv/MBuGU0bV7cGP9K1A3j2Do3yYjvN1dTtY20jBavWNwmWFdXBV6/TRRsgmg==",
       "dependencies": {
-        "@polkadot/api": "13.1.1",
-        "@polkadot/api-augment": "13.1.1",
-        "@polkadot/api-base": "13.1.1",
-        "@polkadot/rpc-core": "13.1.1",
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
+        "@polkadot/api": "13.2.1",
+        "@polkadot/api-augment": "13.2.1",
+        "@polkadot/api-base": "13.2.1",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "@polkadot/util-crypto": "^13.1.1",
         "rxjs": "^7.8.1",
@@ -3460,13 +3490,13 @@
       }
     },
     "node_modules/@polkadot/rpc-augment": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-13.1.1.tgz",
-      "integrity": "sha512-RXcYT+pPkwmAPTpH7DcIjaVEOEzdkAXJBjfF0OxbFKWcqJb8uwRK5PNr7m9OhymwblNFuzmAaLH7bWdzzKiOOA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-13.2.1.tgz",
+      "integrity": "sha512-HkndaAJPR1fi2xrzvP3q4g48WUCb26btGTeg1AKG9FGx9P2dgtpaPRmbMitmgVSzzRurrkxf3Meip8nC7BwDeg==",
       "dependencies": {
-        "@polkadot/rpc-core": "13.1.1",
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "tslib": "^2.7.0"
       },
@@ -3475,13 +3505,13 @@
       }
     },
     "node_modules/@polkadot/rpc-core": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-13.1.1.tgz",
-      "integrity": "sha512-dxb1PFCzP9A8go/20KO+nNiqYMjsjY2gU/w0iPyLVH64yI9CW8GWd+77oEmcAuHKMPEHgpfa6sGuR/r0z+M5SQ==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-13.2.1.tgz",
+      "integrity": "sha512-hy0GksUlb/TfQ38m3ysIWj3qD+rIsyCdxx8Ug5rIx1u0odv86NZ7nTqtH066Ct2riVaPBgBkObFnlpDWTJ6auA==",
       "dependencies": {
-        "@polkadot/rpc-augment": "13.1.1",
-        "@polkadot/rpc-provider": "13.1.1",
-        "@polkadot/types": "13.1.1",
+        "@polkadot/rpc-augment": "13.2.1",
+        "@polkadot/rpc-provider": "13.2.1",
+        "@polkadot/types": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "rxjs": "^7.8.1",
         "tslib": "^2.7.0"
@@ -3491,13 +3521,13 @@
       }
     },
     "node_modules/@polkadot/rpc-provider": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-13.1.1.tgz",
-      "integrity": "sha512-9tG8fEZWsxCoF6PKGECIQHp2tORKt6yIESSdg3pWSP/4xzBEQulqn0SKHcOZV/wwY8goSmw14dA0iyJdLFRP5g==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-13.2.1.tgz",
+      "integrity": "sha512-bbMVYHTNFUa89aY3UQ1hFYD+dP+v+0vhjsnHYYlv37rSUTqOGqW91rkHd63xYCpLAimFt7KRw8xR+SMSYiuDjw==",
       "dependencies": {
         "@polkadot/keyring": "^13.1.1",
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-support": "13.1.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-support": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "@polkadot/util-crypto": "^13.1.1",
         "@polkadot/x-fetch": "^13.1.1",
@@ -3516,14 +3546,14 @@
       }
     },
     "node_modules/@polkadot/types": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-13.1.1.tgz",
-      "integrity": "sha512-ijNlMGgoUtPtjZCzBHqPJXd9PGwE+kKy7qzQ/Xav4RAMD8X/Mo+9okam755J9WNHCOcajVIQo0PDYeZzLYVk1Q==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-13.2.1.tgz",
+      "integrity": "sha512-5yQ0mHMNvwgXeHQ1RZOuHaeak3utAdcBqCpHoagnYrAnGHqtO7kg7YLtT4LkFw2nwL85axu8tOQMv6/3kpFy9w==",
       "dependencies": {
         "@polkadot/keyring": "^13.1.1",
-        "@polkadot/types-augment": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
-        "@polkadot/types-create": "13.1.1",
+        "@polkadot/types-augment": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/types-create": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "@polkadot/util-crypto": "^13.1.1",
         "rxjs": "^7.8.1",
@@ -3534,12 +3564,12 @@
       }
     },
     "node_modules/@polkadot/types-augment": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-13.1.1.tgz",
-      "integrity": "sha512-ltsznxCNJR/RKMEbBgwAC9VgbJBYT08MltDiZKOnjJD+Uk2RnOkTpnV/rOCd6MxQ1TNQV/KBCvWT2Y0pK5Gw0Q==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-13.2.1.tgz",
+      "integrity": "sha512-FpV7/2kIJmmswRmwUbp41lixdNX15olueUjHnSweFk0xEn2Ur43oC0Y3eU3Ab7Y5gPJpceMCfwYz+PjCUGedDA==",
       "dependencies": {
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "tslib": "^2.7.0"
       },
@@ -3548,9 +3578,9 @@
       }
     },
     "node_modules/@polkadot/types-codec": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-13.1.1.tgz",
-      "integrity": "sha512-sSvtUtP7YxhlKjN0HIFWIlDUsAxQbJqnAGmFadx4FT6jjHpKSyxi1bBVI5fJqlYVereHkFWhPYX044DIjZnk7w==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-13.2.1.tgz",
+      "integrity": "sha512-tFAzzS8sMYItoD5a91sFMD+rskWyv4WjSmUZaj0Y4OfLtDAiQvgO0KncdGJIB6D+zZ/T7khpgsv/CZbN3YnezA==",
       "dependencies": {
         "@polkadot/util": "^13.1.1",
         "@polkadot/x-bigint": "^13.1.1",
@@ -3561,11 +3591,11 @@
       }
     },
     "node_modules/@polkadot/types-create": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-13.1.1.tgz",
-      "integrity": "sha512-l3LBsMKtx6tYtqxY3IiBEfKtcRacyaKo9YWnh8QDtXlMwBgs+2KJj8sA8/y2OHOSiKYiffz8M/B7KHL7pF5s3Q==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-13.2.1.tgz",
+      "integrity": "sha512-O/WKdsrNuMaZLf+XRCdum2xJYs5OKC6N3EMPF5Uhg10b80Y/hQCbzA/iWd3/aMNDLUA5XWhixwzJdrZWIMVIzg==",
       "dependencies": {
-        "@polkadot/types-codec": "13.1.1",
+        "@polkadot/types-codec": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "tslib": "^2.7.0"
       },
@@ -3574,14 +3604,14 @@
       }
     },
     "node_modules/@polkadot/types-known": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-13.1.1.tgz",
-      "integrity": "sha512-VY7WbcAhaadNarQXC8TaP+M262a+79091dAU1KYYTHxzCndC72ly0rSA+pZZ4bVloKdHrq6Xh3paAISSoEDXhg==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-13.2.1.tgz",
+      "integrity": "sha512-uz3c4/IvspLpgN8q15A+QH8KWFauzcrV3RfLFlMP2BkkF5qpOwNeP7c4U8j0CZGQySqBsJRCGWmgBXrXg669KA==",
       "dependencies": {
         "@polkadot/networks": "^13.1.1",
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
-        "@polkadot/types-create": "13.1.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/types-create": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "tslib": "^2.7.0"
       },
@@ -3590,9 +3620,9 @@
       }
     },
     "node_modules/@polkadot/types-support": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-13.1.1.tgz",
-      "integrity": "sha512-Xjj25175i4X39N37polUxZqtlloa5G5eizEbzk4qKvFdWuvPe6pOVS63oS7WzMhGbZi2PecThDFRz+GptcHqXQ==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-13.2.1.tgz",
+      "integrity": "sha512-jSbbUTXU+yZJQPRAWmxaDoe4NRO6SjpZPzBIbpuiadx1slON8XB80fVYIGBXuM2xRVrNrB6fCjyCTG7Razj6Hg==",
       "dependencies": {
         "@polkadot/util": "^13.1.1",
         "tslib": "^2.7.0"
@@ -5126,6 +5156,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "license": "MIT",
@@ -5146,6 +5182,12 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
     },
     "node_modules/@types/mocha": {
       "version": "10.0.8",
@@ -5229,16 +5271,16 @@
       "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.6.0.tgz",
-      "integrity": "sha512-UOaz/wFowmoh2G6Mr9gw60B1mm0MzUtm6Ic8G2yM1Le6gyj5Loi/N+O5mocugRGY+8OeeKmkMmbxNqUCq3B4Sg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.7.0.tgz",
+      "integrity": "sha512-RIHOoznhA3CCfSTFiB6kBGLQtB/sox+pJ6jeFu6FxJvqL8qRxq/FfGO/UhsGgQM9oGdXkV4xUgli+dt26biB6A==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.6.0",
-        "@typescript-eslint/type-utils": "8.6.0",
-        "@typescript-eslint/utils": "8.6.0",
-        "@typescript-eslint/visitor-keys": "8.6.0",
+        "@typescript-eslint/scope-manager": "8.7.0",
+        "@typescript-eslint/type-utils": "8.7.0",
+        "@typescript-eslint/utils": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -5262,15 +5304,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.6.0.tgz",
-      "integrity": "sha512-eQcbCuA2Vmw45iGfcyG4y6rS7BhWfz9MQuk409WD47qMM+bKCGQWXxvoOs1DUp+T7UBMTtRTVT+kXr7Sh4O9Ow==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.7.0.tgz",
+      "integrity": "sha512-lN0btVpj2unxHlNYLI//BQ7nzbMJYBVQX5+pbNXvGYazdlgYonMn4AhhHifQ+J4fGRYA/m1DjaQjx+fDetqBOQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.6.0",
-        "@typescript-eslint/types": "8.6.0",
-        "@typescript-eslint/typescript-estree": "8.6.0",
-        "@typescript-eslint/visitor-keys": "8.6.0",
+        "@typescript-eslint/scope-manager": "8.7.0",
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/typescript-estree": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -5290,13 +5332,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.6.0.tgz",
-      "integrity": "sha512-ZuoutoS5y9UOxKvpc/GkvF4cuEmpokda4wRg64JEia27wX+PysIE9q+lzDtlHHgblwUWwo5/Qn+/WyTUvDwBHw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.7.0.tgz",
+      "integrity": "sha512-87rC0k3ZlDOuz82zzXRtQ7Akv3GKhHs0ti4YcbAJtaomllXoSO8hi7Ix3ccEvCd824dy9aIX+j3d2UMAfCtVpg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.6.0",
-        "@typescript-eslint/visitor-keys": "8.6.0"
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5307,13 +5349,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.6.0.tgz",
-      "integrity": "sha512-dtePl4gsuenXVwC7dVNlb4mGDcKjDT/Ropsk4za/ouMBPplCLyznIaR+W65mvCvsyS97dymoBRrioEXI7k0XIg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.7.0.tgz",
+      "integrity": "sha512-tl0N0Mj3hMSkEYhLkjREp54OSb/FI6qyCzfiiclvJvOqre6hsZTGSnHtmFLDU8TIM62G7ygEa1bI08lcuRwEnQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.6.0",
-        "@typescript-eslint/utils": "8.6.0",
+        "@typescript-eslint/typescript-estree": "8.7.0",
+        "@typescript-eslint/utils": "8.7.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -5331,9 +5373,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.6.0.tgz",
-      "integrity": "sha512-rojqFZGd4MQxw33SrOy09qIDS8WEldM8JWtKQLAjf/X5mGSeEFh5ixQlxssMNyPslVIk9yzWqXCsV2eFhYrYUw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.7.0.tgz",
+      "integrity": "sha512-LLt4BLHFwSfASHSF2K29SZ+ZCsbQOM+LuarPjRUuHm+Qd09hSe3GCeaQbcCr+Mik+0QFRmep/FyZBO6fJ64U3w==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5344,13 +5386,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.6.0.tgz",
-      "integrity": "sha512-MOVAzsKJIPIlLK239l5s06YXjNqpKTVhBVDnqUumQJja5+Y94V3+4VUFRA0G60y2jNnTVwRCkhyGQpavfsbq/g==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.7.0.tgz",
+      "integrity": "sha512-MC8nmcGHsmfAKxwnluTQpNqceniT8SteVwd2voYlmiSWGOtjvGXdPl17dYu2797GVscK30Z04WRM28CrKS9WOg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.6.0",
-        "@typescript-eslint/visitor-keys": "8.6.0",
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -5387,15 +5429,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.6.0.tgz",
-      "integrity": "sha512-eNp9cWnYf36NaOVjkEUznf6fEgVy1TWpE0o52e4wtojjBx7D1UV2WAWGzR+8Y5lVFtpMLPwNbC67T83DWSph4A==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.7.0.tgz",
+      "integrity": "sha512-ZbdUdwsl2X/s3CiyAu3gOlfQzpbuG3nTWKPoIvAu1pu5r8viiJvv2NPN2AqArL35NCYtw/lrPPfM4gxrMLNLPw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.6.0",
-        "@typescript-eslint/types": "8.6.0",
-        "@typescript-eslint/typescript-estree": "8.6.0"
+        "@typescript-eslint/scope-manager": "8.7.0",
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/typescript-estree": "8.7.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5409,12 +5451,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.6.0.tgz",
-      "integrity": "sha512-wapVFfZg9H0qOYh4grNVQiMklJGluQrOUiOhYRrQWhx7BY/+I1IYb8BczWNbbUpO+pqy0rDciv3lQH5E1bCLrg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.7.0.tgz",
+      "integrity": "sha512-b1tx0orFCCh/THWPQa2ZwWzvOeyzzp36vkJYOpVg0u8UVOIsfVrnuC9FqAw9gRKn+rG2VmWQ/zDJZzkxUnj/XQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/types": "8.7.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -6582,20 +6624,23 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.10.0.tgz",
-      "integrity": "sha512-Y4D0IgtBZfOcOUAIQTSXBKoNGfY0REGqHJG6+Q81vNippW5YlKjHFj4soMxamKK1NXHUWuBZTLdU3Km+L/pcHw==",
+      "version": "9.11.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.11.1.tgz",
+      "integrity": "sha512-MobhYKIoAO1s1e4VUrgx1l1Sk2JBR/Gqjjgw8+mfgoLE2xwsHur4gdfTxyTgShrhvdVFTaJSgMiQBl1jv/AWxg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.11.0",
         "@eslint/config-array": "^0.18.0",
+        "@eslint/core": "^0.6.0",
         "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.10.0",
-        "@eslint/plugin-kit": "^0.1.0",
+        "@eslint/js": "9.11.1",
+        "@eslint/plugin-kit": "^0.2.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.3.0",
         "@nodelib/fs.walk": "^1.2.8",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -11515,14 +11560,14 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.6.0.tgz",
-      "integrity": "sha512-eEhhlxCEpCd4helh3AO1hk0UP2MvbRi9CtIAJTVPQjuSXOOO2jsEacNi4UdcJzZJbeuVg1gMhtZ8UYb+NFYPrA==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.7.0.tgz",
+      "integrity": "sha512-nEHbEYJyHwsuf7c3V3RS7Saq+1+la3i0ieR3qP0yjqWSzVmh8Drp47uOl9LjbPANac4S7EFSqvcYIKXUUwIfIQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.6.0",
-        "@typescript-eslint/parser": "8.6.0",
-        "@typescript-eslint/utils": "8.6.0"
+        "@typescript-eslint/eslint-plugin": "8.7.0",
+        "@typescript-eslint/parser": "8.7.0",
+        "@typescript-eslint/utils": "8.7.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -21,9 +21,9 @@
     "@frequency-chain/api-augment": "file:../js/api-augment/dist/frequency-chain-api-augment-0.0.0.tgz",
     "@helia/unixfs": "^3.0.7",
     "@noble/curves": "^1.6.0",
-    "@polkadot-api/merkleize-metadata": "^1.1.2",
-    "@polkadot/api": "13.1.1",
-    "@polkadot/types": "13.1.1",
+    "@polkadot-api/merkleize-metadata": "^1.1.3",
+    "@polkadot/api": "13.2.1",
+    "@polkadot/types": "13.2.1",
     "@polkadot/util": "13.1.1",
     "helia": "^4.2.6",
     "multiformats": "^13.3.0",
@@ -31,10 +31,10 @@
     "workerpool": "^9.1.3"
   },
   "devDependencies": {
-    "@eslint/js": "^9.10.0",
+    "@eslint/js": "^9.11.1",
     "@types/mocha": "^10.0.8",
     "@types/workerpool": "^6.4.7",
-    "eslint": "^9.10.0",
+    "eslint": "^9.11.1",
     "eslint-plugin-mocha": "^10.5.0",
     "globals": "^15.9.0",
     "mocha": "^10.7.3",
@@ -43,6 +43,6 @@
     "sinon": "^19.0.2",
     "tsx": "^4.19.1",
     "typescript": "^5.6.2",
-    "typescript-eslint": "^8.6.0"
+    "typescript-eslint": "^8.7.0"
   }
 }

--- a/js/api-augment/definitions/schemas.ts
+++ b/js/api-augment/definitions/schemas.ts
@@ -66,7 +66,7 @@ export default {
     SchemasRuntimeApi: [
       {
         methods: {
-          get_schema_by_id: {
+          get_by_schema_id: {
             description: 'Fetch the schema by id',
             params: [
               {

--- a/js/api-augment/package-lock.json
+++ b/js/api-augment/package-lock.json
@@ -9,22 +9,22 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/api": "^13.1.1",
-        "@polkadot/rpc-provider": "^13.1.1",
-        "@polkadot/types": "^13.1.1",
+        "@polkadot/api": "^13.2.1",
+        "@polkadot/rpc-provider": "^13.2.1",
+        "@polkadot/types": "^13.2.1",
         "globals": "^15.9.0"
       },
       "devDependencies": {
-        "@eslint/js": "^9.10.0",
-        "@polkadot/typegen": "^13.1.1",
+        "@eslint/js": "^9.11.1",
+        "@polkadot/typegen": "^13.2.1",
         "@types/mocha": "^10.0.8",
-        "eslint": "^9.10.0",
+        "eslint": "^9.11.1",
         "eslint-plugin-mocha": "^10.5.0",
         "mocha": "10.7.3",
         "prettier": "^3.3.3",
         "tsx": "^4.19.1",
         "typescript": "^5.6.2",
-        "typescript-eslint": "^8.6.0"
+        "typescript-eslint": "^8.7.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -34,70 +34,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.0.tgz",
-      "integrity": "sha512-3sG8Zwa5fMcA9bgqB8AfWPQ+HFke6uD3h1s3RIwUNK8EG7a4buxvuFTs3j1IMs2NXAk9F30C/FF4vxRgQCcmoQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.0.tgz",
-      "integrity": "sha512-+KuOHTKKyIKgEEqKbGTK8W7mPp+hKinbMBeEnNzjJGyFcWsfrXjSTNluJHCY1RqhxFurdD8uNXQDei7qDlR6+g==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.0.tgz",
-      "integrity": "sha512-EuHFUYkAVfU4qBdyivULuu03FhJO4IJN9PGuABGrFy4vUuzk91P2d+npxHcFdpUnfYKy0PuV+n6bKIpHOB3prQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.0.tgz",
-      "integrity": "sha512-WRrmKidLoKDl56LsbBMhzTTBxrsVwTKdNbKDalbEZr0tcsBgCLbEtoNthOW6PX942YiYq8HzEnb4yWQMLQuipQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
@@ -111,310 +47,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.0.tgz",
-      "integrity": "sha512-IMQ6eme4AfznElesHUPDZ+teuGwoRmVuuixu7sv92ZkdQcPbsNHzutd+rAfaBKo8YK3IrBEi9SLLKWJdEvJniQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.0.tgz",
-      "integrity": "sha512-0muYWCng5vqaxobq6LB3YNtevDFSAZGlgtLoAc81PjUfiFz36n4KMpwhtAd4he8ToSI3TGyuhyx5xmiWNYZFyw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.0.tgz",
-      "integrity": "sha512-XKDVu8IsD0/q3foBzsXGt/KjD/yTKBCIwOHE1XwiXmrRwrX6Hbnd5Eqn/WvDekddK21tfszBSrE/WMaZh+1buQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.0.tgz",
-      "integrity": "sha512-SEELSTEtOFu5LPykzA395Mc+54RMg1EUgXP+iw2SJ72+ooMwVsgfuwXo5Fn0wXNgWZsTVHwY2cg4Vi/bOD88qw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.0.tgz",
-      "integrity": "sha512-j1t5iG8jE7BhonbsEg5d9qOYcVZv/Rv6tghaXM/Ug9xahM0nX/H2gfu6X6z11QRTMT6+aywOMA8TDkhPo8aCGw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.0.tgz",
-      "integrity": "sha512-P7O5Tkh2NbgIm2R6x1zGJJsnacDzTFcRWZyTTMgFdVit6E98LTxO+v8LCCLWRvPrjdzXHx9FEOA8oAZPyApWUA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.0.tgz",
-      "integrity": "sha512-InQwepswq6urikQiIC/kkx412fqUZudBO4SYKu0N+tGhXRWUqAx+Q+341tFV6QdBifpjYgUndV1hhMq3WeJi7A==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.0.tgz",
-      "integrity": "sha512-J9rflLtqdYrxHv2FqXE2i1ELgNjT+JFURt/uDMoPQLcjWQA5wDKgQA4t/dTqGa88ZVECKaD0TctwsUfHbVoi4w==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.0.tgz",
-      "integrity": "sha512-cShCXtEOVc5GxU0fM+dsFD10qZ5UpcQ8AM22bYj0u/yaAykWnqXJDpd77ublcX6vdDsWLuweeuSNZk4yUxZwtw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.0.tgz",
-      "integrity": "sha512-HEtaN7Y5UB4tZPeQmgz/UhzoEyYftbMXrBCUjINGjh3uil+rB/QzzpMshz3cNUxqXN7Vr93zzVtpIDL99t9aRw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.0.tgz",
-      "integrity": "sha512-WDi3+NVAuyjg/Wxi+o5KPqRbZY0QhI9TjrEEm+8dmpY9Xir8+HE/HNx2JoLckhKbFopW0RdO2D72w8trZOV+Wg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.0.tgz",
-      "integrity": "sha512-a3pMQhUEJkITgAw6e0bWA+F+vFtCciMjW/LPtoj99MhVt+Mfb6bbL9hu2wmTZgNd994qTAEw+U/r6k3qHWWaOQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.0.tgz",
-      "integrity": "sha512-cRK+YDem7lFTs2Q5nEv/HHc4LnrfBCbH5+JHu6wm2eP+d8OZNoSMYgPZJq78vqQ9g+9+nMuIsAO7skzphRXHyw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.0.tgz",
-      "integrity": "sha512-suXjq53gERueVWu0OKxzWqk7NxiUWSUlrxoZK7usiF50C6ipColGR5qie2496iKGYNLhDZkPxBI3erbnYkU0rQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.0.tgz",
-      "integrity": "sha512-6p3nHpby0DM/v15IFKMjAaayFhqnXV52aEmv1whZHX56pdkK+MEaLoQWj+H42ssFarP1PcomVhbsR4pkz09qBg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.0.tgz",
-      "integrity": "sha512-BFelBGfrBwk6LVrmFzCq1u1dZbG4zy/Kp93w2+y83Q5UGYF1d8sCzeLI9NXjKyujjBBniQa8R8PzLFAUrSM9OA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.0.tgz",
-      "integrity": "sha512-lY6AC8p4Cnb7xYHuIxQ6iYPe6MfO2CC43XXKo9nBXDb35krYt7KGhQnOkRGar5psxYkircpCqfbNDB4uJbS2jQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.0.tgz",
-      "integrity": "sha512-7L1bHlOTcO4ByvI7OXVI5pNN6HSu6pUQq9yodga8izeuB1KcT2UkHaH6118QJwopExPn0rMHIseCTx1CRo/uNA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.0.tgz",
-      "integrity": "sha512-Arm+WgUFLUATuoxCJcahGuk6Yj9Pzxd6l11Zb/2aAuv5kWWvvfhLFo2fni4uSK5vzlUdCGZ/BdV5tH8klj8p8g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -458,6 +90,15 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/core": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.6.0.tgz",
+      "integrity": "sha512-8I2Q8ykA4J0x0o7cg67FPVnehcqWTBehu/lmY+bolPFHGjh49YzGBMXTvpqVgEbBdvNCSxj6iFgiIyHzf03lzg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
@@ -494,9 +135,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.10.0.tgz",
-      "integrity": "sha512-fuXtbiP5GWIn8Fz+LWoOMVf/Jxm+aajZYkhi6CuEm4SxymFM+eUWzbO9qXT+L0iCkL5+KGYMCSGxo686H19S1g==",
+      "version": "9.11.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.11.1.tgz",
+      "integrity": "sha512-/qu+TWz8WwPWc7/HcIJKi+c+MOm46GdVaSlTTQcaqaL53+GsoA6MxWp5PtTx48qbSP7ylM1Kn7nhvkugfJvRSA==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -512,9 +153,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.1.0.tgz",
-      "integrity": "sha512-autAXT203ixhqei9xt+qkYOvY8l6LAFIdT2UXc/RPNeUVfqRF1BV94GTJyVPFKT8nFM6MyVJhjLj9E8JWvf5zQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
+      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
       "dev": true,
       "dependencies": {
         "levn": "^0.4.1"
@@ -675,22 +316,22 @@
       "optional": true
     },
     "node_modules/@polkadot/api": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-13.1.1.tgz",
-      "integrity": "sha512-s4BTMKcf/3YoU14C0GmRC9APQTilNR/kNprRrfP1S+6umwsNoSuFXSZhaUWUovVlNWw7v7dca8NbFDSTjkoS4w==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-13.2.1.tgz",
+      "integrity": "sha512-QvgKD3/q6KIU3ZuNYFJUNc6B8bGBoqeMF+iaPxJn3Twhh4iVD5XIymD5fVszSqiL1uPXMhzcWecjwE8rDidBoQ==",
       "dependencies": {
-        "@polkadot/api-augment": "13.1.1",
-        "@polkadot/api-base": "13.1.1",
-        "@polkadot/api-derive": "13.1.1",
+        "@polkadot/api-augment": "13.2.1",
+        "@polkadot/api-base": "13.2.1",
+        "@polkadot/api-derive": "13.2.1",
         "@polkadot/keyring": "^13.1.1",
-        "@polkadot/rpc-augment": "13.1.1",
-        "@polkadot/rpc-core": "13.1.1",
-        "@polkadot/rpc-provider": "13.1.1",
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-augment": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
-        "@polkadot/types-create": "13.1.1",
-        "@polkadot/types-known": "13.1.1",
+        "@polkadot/rpc-augment": "13.2.1",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/rpc-provider": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-augment": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/types-create": "13.2.1",
+        "@polkadot/types-known": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "@polkadot/util-crypto": "^13.1.1",
         "eventemitter3": "^5.0.1",
@@ -702,15 +343,15 @@
       }
     },
     "node_modules/@polkadot/api-augment": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-13.1.1.tgz",
-      "integrity": "sha512-QWqw2zWpEEyP2s220b6rv0iq44XwhqQabicpGzCeMPAEJOnvzGjZMVD95o2C3oOq1FR025wQ1CU+4la2P4djNw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-13.2.1.tgz",
+      "integrity": "sha512-NTkI+/Hm48eWc/4Ojh/5elxnjnow5ptXK97IZdkWAe7mWi9hJR05Uq5lGt/T/57E9LSRWEuYje8cIDS3jbbAAw==",
       "dependencies": {
-        "@polkadot/api-base": "13.1.1",
-        "@polkadot/rpc-augment": "13.1.1",
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-augment": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
+        "@polkadot/api-base": "13.2.1",
+        "@polkadot/rpc-augment": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-augment": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "tslib": "^2.7.0"
       },
@@ -719,12 +360,12 @@
       }
     },
     "node_modules/@polkadot/api-base": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-13.1.1.tgz",
-      "integrity": "sha512-VEIOit6oTkOUi3CRUD1c6b/QF3cP0J1XxyMJR5q1/58fgTeUBjREmIyDgZzoXNX5ZK/9VD6pzqoWnKMeJGV5dA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-13.2.1.tgz",
+      "integrity": "sha512-00twdIjTjzdYNdU19i2YKLoWBmf2Yr6b3qrvqIVScHipUkKMbfFBgoPRB5FtcviBbEvLurgfyzHklwnrbWo8GQ==",
       "dependencies": {
-        "@polkadot/rpc-core": "13.1.1",
-        "@polkadot/types": "13.1.1",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/types": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "rxjs": "^7.8.1",
         "tslib": "^2.7.0"
@@ -734,16 +375,16 @@
       }
     },
     "node_modules/@polkadot/api-derive": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-13.1.1.tgz",
-      "integrity": "sha512-Avj4iSZlXXAPEhwnVAA0ZczW1HsgYYIpJFeC6Em3FhpDl4GLxS/UqwpGRhr97Ibqj6Ukv0dJ755xljyXkXiP+A==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-13.2.1.tgz",
+      "integrity": "sha512-npxvS0kYcSFqmYv2G8QKWAJwFhIv/MBuGU0bV7cGP9K1A3j2Do3yYjvN1dTtY20jBavWNwmWFdXBV6/TRRsgmg==",
       "dependencies": {
-        "@polkadot/api": "13.1.1",
-        "@polkadot/api-augment": "13.1.1",
-        "@polkadot/api-base": "13.1.1",
-        "@polkadot/rpc-core": "13.1.1",
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
+        "@polkadot/api": "13.2.1",
+        "@polkadot/api-augment": "13.2.1",
+        "@polkadot/api-base": "13.2.1",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "@polkadot/util-crypto": "^13.1.1",
         "rxjs": "^7.8.1",
@@ -784,13 +425,13 @@
       }
     },
     "node_modules/@polkadot/rpc-augment": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-13.1.1.tgz",
-      "integrity": "sha512-RXcYT+pPkwmAPTpH7DcIjaVEOEzdkAXJBjfF0OxbFKWcqJb8uwRK5PNr7m9OhymwblNFuzmAaLH7bWdzzKiOOA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-13.2.1.tgz",
+      "integrity": "sha512-HkndaAJPR1fi2xrzvP3q4g48WUCb26btGTeg1AKG9FGx9P2dgtpaPRmbMitmgVSzzRurrkxf3Meip8nC7BwDeg==",
       "dependencies": {
-        "@polkadot/rpc-core": "13.1.1",
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "tslib": "^2.7.0"
       },
@@ -799,13 +440,13 @@
       }
     },
     "node_modules/@polkadot/rpc-core": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-13.1.1.tgz",
-      "integrity": "sha512-dxb1PFCzP9A8go/20KO+nNiqYMjsjY2gU/w0iPyLVH64yI9CW8GWd+77oEmcAuHKMPEHgpfa6sGuR/r0z+M5SQ==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-13.2.1.tgz",
+      "integrity": "sha512-hy0GksUlb/TfQ38m3ysIWj3qD+rIsyCdxx8Ug5rIx1u0odv86NZ7nTqtH066Ct2riVaPBgBkObFnlpDWTJ6auA==",
       "dependencies": {
-        "@polkadot/rpc-augment": "13.1.1",
-        "@polkadot/rpc-provider": "13.1.1",
-        "@polkadot/types": "13.1.1",
+        "@polkadot/rpc-augment": "13.2.1",
+        "@polkadot/rpc-provider": "13.2.1",
+        "@polkadot/types": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "rxjs": "^7.8.1",
         "tslib": "^2.7.0"
@@ -815,13 +456,13 @@
       }
     },
     "node_modules/@polkadot/rpc-provider": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-13.1.1.tgz",
-      "integrity": "sha512-9tG8fEZWsxCoF6PKGECIQHp2tORKt6yIESSdg3pWSP/4xzBEQulqn0SKHcOZV/wwY8goSmw14dA0iyJdLFRP5g==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-13.2.1.tgz",
+      "integrity": "sha512-bbMVYHTNFUa89aY3UQ1hFYD+dP+v+0vhjsnHYYlv37rSUTqOGqW91rkHd63xYCpLAimFt7KRw8xR+SMSYiuDjw==",
       "dependencies": {
         "@polkadot/keyring": "^13.1.1",
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-support": "13.1.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-support": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "@polkadot/util-crypto": "^13.1.1",
         "@polkadot/x-fetch": "^13.1.1",
@@ -840,20 +481,20 @@
       }
     },
     "node_modules/@polkadot/typegen": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/typegen/-/typegen-13.1.1.tgz",
-      "integrity": "sha512-YZP9pxrLinEg3O9W56//IhH3EkymCqzIWdppkH8WSWKsAZCXY019pgP2de4GK5TxLCBLdLU7LEPLqLNzHegI+Q==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/typegen/-/typegen-13.2.1.tgz",
+      "integrity": "sha512-1916yGnWtks7ipecuXEMtLzvfLzS/Djb5gYv5y/82RbcsRQDHOtMj6NeLp0SNBpDrpYxuVETRXQe0JLd7QpAWA==",
       "dev": true,
       "dependencies": {
-        "@polkadot/api": "13.1.1",
-        "@polkadot/api-augment": "13.1.1",
-        "@polkadot/rpc-augment": "13.1.1",
-        "@polkadot/rpc-provider": "13.1.1",
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-augment": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
-        "@polkadot/types-create": "13.1.1",
-        "@polkadot/types-support": "13.1.1",
+        "@polkadot/api": "13.2.1",
+        "@polkadot/api-augment": "13.2.1",
+        "@polkadot/rpc-augment": "13.2.1",
+        "@polkadot/rpc-provider": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-augment": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/types-create": "13.2.1",
+        "@polkadot/types-support": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "@polkadot/util-crypto": "^13.1.1",
         "@polkadot/x-ws": "^13.1.1",
@@ -914,14 +555,14 @@
       }
     },
     "node_modules/@polkadot/types": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-13.1.1.tgz",
-      "integrity": "sha512-ijNlMGgoUtPtjZCzBHqPJXd9PGwE+kKy7qzQ/Xav4RAMD8X/Mo+9okam755J9WNHCOcajVIQo0PDYeZzLYVk1Q==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-13.2.1.tgz",
+      "integrity": "sha512-5yQ0mHMNvwgXeHQ1RZOuHaeak3utAdcBqCpHoagnYrAnGHqtO7kg7YLtT4LkFw2nwL85axu8tOQMv6/3kpFy9w==",
       "dependencies": {
         "@polkadot/keyring": "^13.1.1",
-        "@polkadot/types-augment": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
-        "@polkadot/types-create": "13.1.1",
+        "@polkadot/types-augment": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/types-create": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "@polkadot/util-crypto": "^13.1.1",
         "rxjs": "^7.8.1",
@@ -932,12 +573,12 @@
       }
     },
     "node_modules/@polkadot/types-augment": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-13.1.1.tgz",
-      "integrity": "sha512-ltsznxCNJR/RKMEbBgwAC9VgbJBYT08MltDiZKOnjJD+Uk2RnOkTpnV/rOCd6MxQ1TNQV/KBCvWT2Y0pK5Gw0Q==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-13.2.1.tgz",
+      "integrity": "sha512-FpV7/2kIJmmswRmwUbp41lixdNX15olueUjHnSweFk0xEn2Ur43oC0Y3eU3Ab7Y5gPJpceMCfwYz+PjCUGedDA==",
       "dependencies": {
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "tslib": "^2.7.0"
       },
@@ -946,9 +587,9 @@
       }
     },
     "node_modules/@polkadot/types-codec": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-13.1.1.tgz",
-      "integrity": "sha512-sSvtUtP7YxhlKjN0HIFWIlDUsAxQbJqnAGmFadx4FT6jjHpKSyxi1bBVI5fJqlYVereHkFWhPYX044DIjZnk7w==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-13.2.1.tgz",
+      "integrity": "sha512-tFAzzS8sMYItoD5a91sFMD+rskWyv4WjSmUZaj0Y4OfLtDAiQvgO0KncdGJIB6D+zZ/T7khpgsv/CZbN3YnezA==",
       "dependencies": {
         "@polkadot/util": "^13.1.1",
         "@polkadot/x-bigint": "^13.1.1",
@@ -959,11 +600,11 @@
       }
     },
     "node_modules/@polkadot/types-create": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-13.1.1.tgz",
-      "integrity": "sha512-l3LBsMKtx6tYtqxY3IiBEfKtcRacyaKo9YWnh8QDtXlMwBgs+2KJj8sA8/y2OHOSiKYiffz8M/B7KHL7pF5s3Q==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-13.2.1.tgz",
+      "integrity": "sha512-O/WKdsrNuMaZLf+XRCdum2xJYs5OKC6N3EMPF5Uhg10b80Y/hQCbzA/iWd3/aMNDLUA5XWhixwzJdrZWIMVIzg==",
       "dependencies": {
-        "@polkadot/types-codec": "13.1.1",
+        "@polkadot/types-codec": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "tslib": "^2.7.0"
       },
@@ -972,14 +613,14 @@
       }
     },
     "node_modules/@polkadot/types-known": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-13.1.1.tgz",
-      "integrity": "sha512-VY7WbcAhaadNarQXC8TaP+M262a+79091dAU1KYYTHxzCndC72ly0rSA+pZZ4bVloKdHrq6Xh3paAISSoEDXhg==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-13.2.1.tgz",
+      "integrity": "sha512-uz3c4/IvspLpgN8q15A+QH8KWFauzcrV3RfLFlMP2BkkF5qpOwNeP7c4U8j0CZGQySqBsJRCGWmgBXrXg669KA==",
       "dependencies": {
         "@polkadot/networks": "^13.1.1",
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
-        "@polkadot/types-create": "13.1.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/types-create": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "tslib": "^2.7.0"
       },
@@ -988,9 +629,9 @@
       }
     },
     "node_modules/@polkadot/types-support": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-13.1.1.tgz",
-      "integrity": "sha512-Xjj25175i4X39N37polUxZqtlloa5G5eizEbzk4qKvFdWuvPe6pOVS63oS7WzMhGbZi2PecThDFRz+GptcHqXQ==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-13.2.1.tgz",
+      "integrity": "sha512-jSbbUTXU+yZJQPRAWmxaDoe4NRO6SjpZPzBIbpuiadx1slON8XB80fVYIGBXuM2xRVrNrB6fCjyCTG7Razj6Hg==",
       "dependencies": {
         "@polkadot/util": "^13.1.1",
         "tslib": "^2.7.0"
@@ -1290,6 +931,18 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
     "node_modules/@types/mocha": {
       "version": "10.0.8",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.8.tgz",
@@ -1305,16 +958,16 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.6.0.tgz",
-      "integrity": "sha512-UOaz/wFowmoh2G6Mr9gw60B1mm0MzUtm6Ic8G2yM1Le6gyj5Loi/N+O5mocugRGY+8OeeKmkMmbxNqUCq3B4Sg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.7.0.tgz",
+      "integrity": "sha512-RIHOoznhA3CCfSTFiB6kBGLQtB/sox+pJ6jeFu6FxJvqL8qRxq/FfGO/UhsGgQM9oGdXkV4xUgli+dt26biB6A==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.6.0",
-        "@typescript-eslint/type-utils": "8.6.0",
-        "@typescript-eslint/utils": "8.6.0",
-        "@typescript-eslint/visitor-keys": "8.6.0",
+        "@typescript-eslint/scope-manager": "8.7.0",
+        "@typescript-eslint/type-utils": "8.7.0",
+        "@typescript-eslint/utils": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -1338,15 +991,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.6.0.tgz",
-      "integrity": "sha512-eQcbCuA2Vmw45iGfcyG4y6rS7BhWfz9MQuk409WD47qMM+bKCGQWXxvoOs1DUp+T7UBMTtRTVT+kXr7Sh4O9Ow==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.7.0.tgz",
+      "integrity": "sha512-lN0btVpj2unxHlNYLI//BQ7nzbMJYBVQX5+pbNXvGYazdlgYonMn4AhhHifQ+J4fGRYA/m1DjaQjx+fDetqBOQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.6.0",
-        "@typescript-eslint/types": "8.6.0",
-        "@typescript-eslint/typescript-estree": "8.6.0",
-        "@typescript-eslint/visitor-keys": "8.6.0",
+        "@typescript-eslint/scope-manager": "8.7.0",
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/typescript-estree": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1366,13 +1019,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.6.0.tgz",
-      "integrity": "sha512-ZuoutoS5y9UOxKvpc/GkvF4cuEmpokda4wRg64JEia27wX+PysIE9q+lzDtlHHgblwUWwo5/Qn+/WyTUvDwBHw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.7.0.tgz",
+      "integrity": "sha512-87rC0k3ZlDOuz82zzXRtQ7Akv3GKhHs0ti4YcbAJtaomllXoSO8hi7Ix3ccEvCd824dy9aIX+j3d2UMAfCtVpg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.6.0",
-        "@typescript-eslint/visitor-keys": "8.6.0"
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1383,13 +1036,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.6.0.tgz",
-      "integrity": "sha512-dtePl4gsuenXVwC7dVNlb4mGDcKjDT/Ropsk4za/ouMBPplCLyznIaR+W65mvCvsyS97dymoBRrioEXI7k0XIg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.7.0.tgz",
+      "integrity": "sha512-tl0N0Mj3hMSkEYhLkjREp54OSb/FI6qyCzfiiclvJvOqre6hsZTGSnHtmFLDU8TIM62G7ygEa1bI08lcuRwEnQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.6.0",
-        "@typescript-eslint/utils": "8.6.0",
+        "@typescript-eslint/typescript-estree": "8.7.0",
+        "@typescript-eslint/utils": "8.7.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -1407,9 +1060,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.6.0.tgz",
-      "integrity": "sha512-rojqFZGd4MQxw33SrOy09qIDS8WEldM8JWtKQLAjf/X5mGSeEFh5ixQlxssMNyPslVIk9yzWqXCsV2eFhYrYUw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.7.0.tgz",
+      "integrity": "sha512-LLt4BLHFwSfASHSF2K29SZ+ZCsbQOM+LuarPjRUuHm+Qd09hSe3GCeaQbcCr+Mik+0QFRmep/FyZBO6fJ64U3w==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1420,13 +1073,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.6.0.tgz",
-      "integrity": "sha512-MOVAzsKJIPIlLK239l5s06YXjNqpKTVhBVDnqUumQJja5+Y94V3+4VUFRA0G60y2jNnTVwRCkhyGQpavfsbq/g==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.7.0.tgz",
+      "integrity": "sha512-MC8nmcGHsmfAKxwnluTQpNqceniT8SteVwd2voYlmiSWGOtjvGXdPl17dYu2797GVscK30Z04WRM28CrKS9WOg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.6.0",
-        "@typescript-eslint/visitor-keys": "8.6.0",
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1472,15 +1125,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.6.0.tgz",
-      "integrity": "sha512-eNp9cWnYf36NaOVjkEUznf6fEgVy1TWpE0o52e4wtojjBx7D1UV2WAWGzR+8Y5lVFtpMLPwNbC67T83DWSph4A==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.7.0.tgz",
+      "integrity": "sha512-ZbdUdwsl2X/s3CiyAu3gOlfQzpbuG3nTWKPoIvAu1pu5r8viiJvv2NPN2AqArL35NCYtw/lrPPfM4gxrMLNLPw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.6.0",
-        "@typescript-eslint/types": "8.6.0",
-        "@typescript-eslint/typescript-estree": "8.6.0"
+        "@typescript-eslint/scope-manager": "8.7.0",
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/typescript-estree": "8.7.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1494,12 +1147,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.6.0.tgz",
-      "integrity": "sha512-wapVFfZg9H0qOYh4grNVQiMklJGluQrOUiOhYRrQWhx7BY/+I1IYb8BczWNbbUpO+pqy0rDciv3lQH5E1bCLrg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.7.0.tgz",
+      "integrity": "sha512-b1tx0orFCCh/THWPQa2ZwWzvOeyzzp36vkJYOpVg0u8UVOIsfVrnuC9FqAw9gRKn+rG2VmWQ/zDJZzkxUnj/XQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/types": "8.7.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -1874,20 +1527,23 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.10.0.tgz",
-      "integrity": "sha512-Y4D0IgtBZfOcOUAIQTSXBKoNGfY0REGqHJG6+Q81vNippW5YlKjHFj4soMxamKK1NXHUWuBZTLdU3Km+L/pcHw==",
+      "version": "9.11.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.11.1.tgz",
+      "integrity": "sha512-MobhYKIoAO1s1e4VUrgx1l1Sk2JBR/Gqjjgw8+mfgoLE2xwsHur4gdfTxyTgShrhvdVFTaJSgMiQBl1jv/AWxg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.11.0",
         "@eslint/config-array": "^0.18.0",
+        "@eslint/core": "^0.6.0",
         "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.10.0",
-        "@eslint/plugin-kit": "^0.1.0",
+        "@eslint/js": "9.11.1",
+        "@eslint/plugin-kit": "^0.2.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.3.0",
         "@nodelib/fs.walk": "^1.2.8",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -3249,14 +2905,14 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.6.0.tgz",
-      "integrity": "sha512-eEhhlxCEpCd4helh3AO1hk0UP2MvbRi9CtIAJTVPQjuSXOOO2jsEacNi4UdcJzZJbeuVg1gMhtZ8UYb+NFYPrA==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.7.0.tgz",
+      "integrity": "sha512-nEHbEYJyHwsuf7c3V3RS7Saq+1+la3i0ieR3qP0yjqWSzVmh8Drp47uOl9LjbPANac4S7EFSqvcYIKXUUwIfIQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.6.0",
-        "@typescript-eslint/parser": "8.6.0",
-        "@typescript-eslint/utils": "8.6.0"
+        "@typescript-eslint/eslint-plugin": "8.7.0",
+        "@typescript-eslint/parser": "8.7.0",
+        "@typescript-eslint/utils": "8.7.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/js/api-augment/package.json
+++ b/js/api-augment/package.json
@@ -33,21 +33,21 @@
   "author": "frequency-chain",
   "license": "Apache-2.0",
   "dependencies": {
-    "@polkadot/api": "^13.1.1",
-    "@polkadot/rpc-provider": "^13.1.1",
-    "@polkadot/types": "^13.1.1",
+    "@polkadot/api": "^13.2.1",
+    "@polkadot/rpc-provider": "^13.2.1",
+    "@polkadot/types": "^13.2.1",
     "globals": "^15.9.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.10.0",
-    "@polkadot/typegen": "^13.1.1",
+    "@eslint/js": "^9.11.1",
+    "@polkadot/typegen": "^13.2.1",
     "@types/mocha": "^10.0.8",
-    "eslint": "^9.10.0",
+    "eslint": "^9.11.1",
     "eslint-plugin-mocha": "^10.5.0",
     "mocha": "10.7.3",
     "prettier": "^3.3.3",
     "tsx": "^4.19.1",
     "typescript": "^5.6.2",
-    "typescript-eslint": "^8.6.0"
+    "typescript-eslint": "^8.7.0"
   }
 }

--- a/scripts/js/onboard/package-lock.json
+++ b/scripts/js/onboard/package-lock.json
@@ -9,26 +9,31 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/api": "^12.4.2",
-        "@polkadot/util": "^13.0.2",
-        "@polkadot/util-crypto": "^13.0.2"
+        "@polkadot/api": "^13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "@polkadot/util-crypto": "^13.1.1"
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.5.0",
-      "license": "MIT",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
+      "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
       "dependencies": {
-        "@noble/hashes": "1.4.0"
+        "@noble/hashes": "1.5.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "license": "MIT",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -36,17 +41,20 @@
     },
     "node_modules/@polkadot-api/json-rpc-provider": {
       "version": "0.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider/-/json-rpc-provider-0.0.1.tgz",
+      "integrity": "sha512-/SMC/l7foRjpykLTUTacIH05H3mr9ip8b5xxfwXlVezXrNVLp3Cv0GX6uItkKd+ZjzVPf3PFrDF2B2/HLSNESA==",
       "optional": true
     },
     "node_modules/@polkadot-api/json-rpc-provider-proxy": {
       "version": "0.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider-proxy/-/json-rpc-provider-proxy-0.1.0.tgz",
+      "integrity": "sha512-8GSFE5+EF73MCuLQm8tjrbCqlgclcHBSRaswvXziJ0ZW7iw3UEMsKkkKvELayWyBuOPa2T5i1nj6gFOeIsqvrg==",
       "optional": true
     },
     "node_modules/@polkadot-api/metadata-builders": {
       "version": "0.3.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.3.2.tgz",
+      "integrity": "sha512-TKpfoT6vTb+513KDzMBTfCb/ORdgRnsS3TDFpOhAhZ08ikvK+hjHMt5plPiAX/OWkm1Wc9I3+K6W0hX5Ab7MVg==",
       "optional": true,
       "dependencies": {
         "@polkadot-api/substrate-bindings": "0.6.0",
@@ -55,7 +63,8 @@
     },
     "node_modules/@polkadot-api/observable-client": {
       "version": "0.3.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.3.2.tgz",
+      "integrity": "sha512-HGgqWgEutVyOBXoGOPp4+IAq6CNdK/3MfQJmhCJb8YaJiaK4W6aRGrdQuQSTPHfERHCARt9BrOmEvTXAT257Ug==",
       "optional": true,
       "dependencies": {
         "@polkadot-api/metadata-builders": "0.3.2",
@@ -69,7 +78,8 @@
     },
     "node_modules/@polkadot-api/substrate-bindings": {
       "version": "0.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.6.0.tgz",
+      "integrity": "sha512-lGuhE74NA1/PqdN7fKFdE5C1gNYX357j1tWzdlPXI0kQ7h3kN0zfxNOpPUN7dIrPcOFZ6C0tRRVrBylXkI6xPw==",
       "optional": true,
       "dependencies": {
         "@noble/hashes": "^1.3.1",
@@ -80,7 +90,8 @@
     },
     "node_modules/@polkadot-api/substrate-client": {
       "version": "0.1.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-client/-/substrate-client-0.1.4.tgz",
+      "integrity": "sha512-MljrPobN0ZWTpn++da9vOvt+Ex+NlqTlr/XT7zi9sqPtDJiQcYl+d29hFAgpaeTqbeQKZwz3WDE9xcEfLE8c5A==",
       "optional": true,
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "0.0.1",
@@ -89,157 +100,167 @@
     },
     "node_modules/@polkadot-api/utils": {
       "version": "0.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/utils/-/utils-0.1.0.tgz",
+      "integrity": "sha512-MXzWZeuGxKizPx2Xf/47wx9sr/uxKw39bVJUptTJdsaQn/TGq+z310mHzf1RCGvC1diHM8f593KrnDgc9oNbJA==",
       "optional": true
     },
     "node_modules/@polkadot/api": {
-      "version": "12.4.2",
-      "license": "Apache-2.0",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-13.2.1.tgz",
+      "integrity": "sha512-QvgKD3/q6KIU3ZuNYFJUNc6B8bGBoqeMF+iaPxJn3Twhh4iVD5XIymD5fVszSqiL1uPXMhzcWecjwE8rDidBoQ==",
       "dependencies": {
-        "@polkadot/api-augment": "12.4.2",
-        "@polkadot/api-base": "12.4.2",
-        "@polkadot/api-derive": "12.4.2",
-        "@polkadot/keyring": "^13.0.2",
-        "@polkadot/rpc-augment": "12.4.2",
-        "@polkadot/rpc-core": "12.4.2",
-        "@polkadot/rpc-provider": "12.4.2",
-        "@polkadot/types": "12.4.2",
-        "@polkadot/types-augment": "12.4.2",
-        "@polkadot/types-codec": "12.4.2",
-        "@polkadot/types-create": "12.4.2",
-        "@polkadot/types-known": "12.4.2",
-        "@polkadot/util": "^13.0.2",
-        "@polkadot/util-crypto": "^13.0.2",
+        "@polkadot/api-augment": "13.2.1",
+        "@polkadot/api-base": "13.2.1",
+        "@polkadot/api-derive": "13.2.1",
+        "@polkadot/keyring": "^13.1.1",
+        "@polkadot/rpc-augment": "13.2.1",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/rpc-provider": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-augment": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/types-create": "13.2.1",
+        "@polkadot/types-known": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "@polkadot/util-crypto": "^13.1.1",
         "eventemitter3": "^5.0.1",
         "rxjs": "^7.8.1",
-        "tslib": "^2.6.3"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/api-augment": {
-      "version": "12.4.2",
-      "license": "Apache-2.0",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-13.2.1.tgz",
+      "integrity": "sha512-NTkI+/Hm48eWc/4Ojh/5elxnjnow5ptXK97IZdkWAe7mWi9hJR05Uq5lGt/T/57E9LSRWEuYje8cIDS3jbbAAw==",
       "dependencies": {
-        "@polkadot/api-base": "12.4.2",
-        "@polkadot/rpc-augment": "12.4.2",
-        "@polkadot/types": "12.4.2",
-        "@polkadot/types-augment": "12.4.2",
-        "@polkadot/types-codec": "12.4.2",
-        "@polkadot/util": "^13.0.2",
-        "tslib": "^2.6.3"
+        "@polkadot/api-base": "13.2.1",
+        "@polkadot/rpc-augment": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-augment": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/api-base": {
-      "version": "12.4.2",
-      "license": "Apache-2.0",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-13.2.1.tgz",
+      "integrity": "sha512-00twdIjTjzdYNdU19i2YKLoWBmf2Yr6b3qrvqIVScHipUkKMbfFBgoPRB5FtcviBbEvLurgfyzHklwnrbWo8GQ==",
       "dependencies": {
-        "@polkadot/rpc-core": "12.4.2",
-        "@polkadot/types": "12.4.2",
-        "@polkadot/util": "^13.0.2",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/util": "^13.1.1",
         "rxjs": "^7.8.1",
-        "tslib": "^2.6.3"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/api-derive": {
-      "version": "12.4.2",
-      "license": "Apache-2.0",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-13.2.1.tgz",
+      "integrity": "sha512-npxvS0kYcSFqmYv2G8QKWAJwFhIv/MBuGU0bV7cGP9K1A3j2Do3yYjvN1dTtY20jBavWNwmWFdXBV6/TRRsgmg==",
       "dependencies": {
-        "@polkadot/api": "12.4.2",
-        "@polkadot/api-augment": "12.4.2",
-        "@polkadot/api-base": "12.4.2",
-        "@polkadot/rpc-core": "12.4.2",
-        "@polkadot/types": "12.4.2",
-        "@polkadot/types-codec": "12.4.2",
-        "@polkadot/util": "^13.0.2",
-        "@polkadot/util-crypto": "^13.0.2",
+        "@polkadot/api": "13.2.1",
+        "@polkadot/api-augment": "13.2.1",
+        "@polkadot/api-base": "13.2.1",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "@polkadot/util-crypto": "^13.1.1",
         "rxjs": "^7.8.1",
-        "tslib": "^2.6.3"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/keyring": {
-      "version": "13.0.2",
-      "license": "Apache-2.0",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-13.1.1.tgz",
+      "integrity": "sha512-Wm+9gn946GIPjGzvueObLGBBS9s541HE6mvKdWGEmPFMzH93ESN931RZlOd67my5MWryiSP05h5SHTp7bSaQTA==",
       "dependencies": {
-        "@polkadot/util": "13.0.2",
-        "@polkadot/util-crypto": "13.0.2",
-        "tslib": "^2.6.2"
+        "@polkadot/util": "13.1.1",
+        "@polkadot/util-crypto": "13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "13.0.2",
-        "@polkadot/util-crypto": "13.0.2"
+        "@polkadot/util": "13.1.1",
+        "@polkadot/util-crypto": "13.1.1"
       }
     },
     "node_modules/@polkadot/networks": {
-      "version": "13.0.2",
-      "license": "Apache-2.0",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-13.1.1.tgz",
+      "integrity": "sha512-eEQ4+Mfl1xFtApeU5PdXZ2XBhxNSvUz9yW+YQVGUCkXRjWFbqNRsTOYWGd9uFbiAOXiiiXbtqfZpxSDzIm4XOg==",
       "dependencies": {
-        "@polkadot/util": "13.0.2",
-        "@substrate/ss58-registry": "^1.46.0",
-        "tslib": "^2.6.2"
+        "@polkadot/util": "13.1.1",
+        "@substrate/ss58-registry": "^1.50.0",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/rpc-augment": {
-      "version": "12.4.2",
-      "license": "Apache-2.0",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-13.2.1.tgz",
+      "integrity": "sha512-HkndaAJPR1fi2xrzvP3q4g48WUCb26btGTeg1AKG9FGx9P2dgtpaPRmbMitmgVSzzRurrkxf3Meip8nC7BwDeg==",
       "dependencies": {
-        "@polkadot/rpc-core": "12.4.2",
-        "@polkadot/types": "12.4.2",
-        "@polkadot/types-codec": "12.4.2",
-        "@polkadot/util": "^13.0.2",
-        "tslib": "^2.6.3"
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/rpc-core": {
-      "version": "12.4.2",
-      "license": "Apache-2.0",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-13.2.1.tgz",
+      "integrity": "sha512-hy0GksUlb/TfQ38m3ysIWj3qD+rIsyCdxx8Ug5rIx1u0odv86NZ7nTqtH066Ct2riVaPBgBkObFnlpDWTJ6auA==",
       "dependencies": {
-        "@polkadot/rpc-augment": "12.4.2",
-        "@polkadot/rpc-provider": "12.4.2",
-        "@polkadot/types": "12.4.2",
-        "@polkadot/util": "^13.0.2",
+        "@polkadot/rpc-augment": "13.2.1",
+        "@polkadot/rpc-provider": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/util": "^13.1.1",
         "rxjs": "^7.8.1",
-        "tslib": "^2.6.3"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/rpc-provider": {
-      "version": "12.4.2",
-      "license": "Apache-2.0",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-13.2.1.tgz",
+      "integrity": "sha512-bbMVYHTNFUa89aY3UQ1hFYD+dP+v+0vhjsnHYYlv37rSUTqOGqW91rkHd63xYCpLAimFt7KRw8xR+SMSYiuDjw==",
       "dependencies": {
-        "@polkadot/keyring": "^13.0.2",
-        "@polkadot/types": "12.4.2",
-        "@polkadot/types-support": "12.4.2",
-        "@polkadot/util": "^13.0.2",
-        "@polkadot/util-crypto": "^13.0.2",
-        "@polkadot/x-fetch": "^13.0.2",
-        "@polkadot/x-global": "^13.0.2",
-        "@polkadot/x-ws": "^13.0.2",
+        "@polkadot/keyring": "^13.1.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-support": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "@polkadot/util-crypto": "^13.1.1",
+        "@polkadot/x-fetch": "^13.1.1",
+        "@polkadot/x-global": "^13.1.1",
+        "@polkadot/x-ws": "^13.1.1",
         "eventemitter3": "^5.0.1",
         "mock-socket": "^9.3.1",
         "nock": "^13.5.4",
-        "tslib": "^2.6.3"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
@@ -249,126 +270,135 @@
       }
     },
     "node_modules/@polkadot/types": {
-      "version": "12.4.2",
-      "license": "Apache-2.0",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-13.2.1.tgz",
+      "integrity": "sha512-5yQ0mHMNvwgXeHQ1RZOuHaeak3utAdcBqCpHoagnYrAnGHqtO7kg7YLtT4LkFw2nwL85axu8tOQMv6/3kpFy9w==",
       "dependencies": {
-        "@polkadot/keyring": "^13.0.2",
-        "@polkadot/types-augment": "12.4.2",
-        "@polkadot/types-codec": "12.4.2",
-        "@polkadot/types-create": "12.4.2",
-        "@polkadot/util": "^13.0.2",
-        "@polkadot/util-crypto": "^13.0.2",
+        "@polkadot/keyring": "^13.1.1",
+        "@polkadot/types-augment": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/types-create": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "@polkadot/util-crypto": "^13.1.1",
         "rxjs": "^7.8.1",
-        "tslib": "^2.6.3"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/types-augment": {
-      "version": "12.4.2",
-      "license": "Apache-2.0",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-13.2.1.tgz",
+      "integrity": "sha512-FpV7/2kIJmmswRmwUbp41lixdNX15olueUjHnSweFk0xEn2Ur43oC0Y3eU3Ab7Y5gPJpceMCfwYz+PjCUGedDA==",
       "dependencies": {
-        "@polkadot/types": "12.4.2",
-        "@polkadot/types-codec": "12.4.2",
-        "@polkadot/util": "^13.0.2",
-        "tslib": "^2.6.3"
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/types-codec": {
-      "version": "12.4.2",
-      "license": "Apache-2.0",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-13.2.1.tgz",
+      "integrity": "sha512-tFAzzS8sMYItoD5a91sFMD+rskWyv4WjSmUZaj0Y4OfLtDAiQvgO0KncdGJIB6D+zZ/T7khpgsv/CZbN3YnezA==",
       "dependencies": {
-        "@polkadot/util": "^13.0.2",
-        "@polkadot/x-bigint": "^13.0.2",
-        "tslib": "^2.6.3"
+        "@polkadot/util": "^13.1.1",
+        "@polkadot/x-bigint": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/types-create": {
-      "version": "12.4.2",
-      "license": "Apache-2.0",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-13.2.1.tgz",
+      "integrity": "sha512-O/WKdsrNuMaZLf+XRCdum2xJYs5OKC6N3EMPF5Uhg10b80Y/hQCbzA/iWd3/aMNDLUA5XWhixwzJdrZWIMVIzg==",
       "dependencies": {
-        "@polkadot/types-codec": "12.4.2",
-        "@polkadot/util": "^13.0.2",
-        "tslib": "^2.6.3"
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/types-known": {
-      "version": "12.4.2",
-      "license": "Apache-2.0",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-13.2.1.tgz",
+      "integrity": "sha512-uz3c4/IvspLpgN8q15A+QH8KWFauzcrV3RfLFlMP2BkkF5qpOwNeP7c4U8j0CZGQySqBsJRCGWmgBXrXg669KA==",
       "dependencies": {
-        "@polkadot/networks": "^13.0.2",
-        "@polkadot/types": "12.4.2",
-        "@polkadot/types-codec": "12.4.2",
-        "@polkadot/types-create": "12.4.2",
-        "@polkadot/util": "^13.0.2",
-        "tslib": "^2.6.3"
+        "@polkadot/networks": "^13.1.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/types-create": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/types-support": {
-      "version": "12.4.2",
-      "license": "Apache-2.0",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-13.2.1.tgz",
+      "integrity": "sha512-jSbbUTXU+yZJQPRAWmxaDoe4NRO6SjpZPzBIbpuiadx1slON8XB80fVYIGBXuM2xRVrNrB6fCjyCTG7Razj6Hg==",
       "dependencies": {
-        "@polkadot/util": "^13.0.2",
-        "tslib": "^2.6.3"
+        "@polkadot/util": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/util": {
-      "version": "13.0.2",
-      "license": "Apache-2.0",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.1.1.tgz",
+      "integrity": "sha512-M4iQ5Um8tFdDmD7a96nPzfrEt+kxyWOqQDPqXyaax4QBnq/WCbq0jo8IO61uz55mdMQnGZvq8jd8uge4V6JzzQ==",
       "dependencies": {
-        "@polkadot/x-bigint": "13.0.2",
-        "@polkadot/x-global": "13.0.2",
-        "@polkadot/x-textdecoder": "13.0.2",
-        "@polkadot/x-textencoder": "13.0.2",
+        "@polkadot/x-bigint": "13.1.1",
+        "@polkadot/x-global": "13.1.1",
+        "@polkadot/x-textdecoder": "13.1.1",
+        "@polkadot/x-textencoder": "13.1.1",
         "@types/bn.js": "^5.1.5",
         "bn.js": "^5.2.1",
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/util-crypto": {
-      "version": "13.0.2",
-      "license": "Apache-2.0",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-13.1.1.tgz",
+      "integrity": "sha512-FG68rrLPdfLcscEyH10vnGkakM4O2lqr71S3GDhgc9WXaS8y9jisLgMPg8jbMHiQBJ3iKYkmtPKiLBowRslj2w==",
       "dependencies": {
         "@noble/curves": "^1.3.0",
         "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "13.0.2",
-        "@polkadot/util": "13.0.2",
+        "@polkadot/networks": "13.1.1",
+        "@polkadot/util": "13.1.1",
         "@polkadot/wasm-crypto": "^7.3.2",
         "@polkadot/wasm-util": "^7.3.2",
-        "@polkadot/x-bigint": "13.0.2",
-        "@polkadot/x-randomvalues": "13.0.2",
-        "@scure/base": "^1.1.5",
-        "tslib": "^2.6.2"
+        "@polkadot/x-bigint": "13.1.1",
+        "@polkadot/x-randomvalues": "13.1.1",
+        "@scure/base": "^1.1.7",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "13.0.2"
+        "@polkadot/util": "13.1.1"
       }
     },
     "node_modules/@polkadot/wasm-bridge": {
       "version": "7.3.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.3.2.tgz",
+      "integrity": "sha512-AJEXChcf/nKXd5Q/YLEV5dXQMle3UNT7jcXYmIffZAo/KI394a+/24PaISyQjoNC0fkzS1Q8T5pnGGHmXiVz2g==",
       "dependencies": {
         "@polkadot/wasm-util": "7.3.2",
         "tslib": "^2.6.2"
@@ -383,7 +413,8 @@
     },
     "node_modules/@polkadot/wasm-crypto": {
       "version": "7.3.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.3.2.tgz",
+      "integrity": "sha512-+neIDLSJ6jjVXsjyZ5oLSv16oIpwp+PxFqTUaZdZDoA2EyFRQB8pP7+qLsMNk+WJuhuJ4qXil/7XiOnZYZ+wxw==",
       "dependencies": {
         "@polkadot/wasm-bridge": "7.3.2",
         "@polkadot/wasm-crypto-asmjs": "7.3.2",
@@ -402,7 +433,8 @@
     },
     "node_modules/@polkadot/wasm-crypto-asmjs": {
       "version": "7.3.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.3.2.tgz",
+      "integrity": "sha512-QP5eiUqUFur/2UoF2KKKYJcesc71fXhQFLT3D4ZjG28Mfk2ZPI0QNRUfpcxVQmIUpV5USHg4geCBNuCYsMm20Q==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -415,7 +447,8 @@
     },
     "node_modules/@polkadot/wasm-crypto-init": {
       "version": "7.3.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.3.2.tgz",
+      "integrity": "sha512-FPq73zGmvZtnuJaFV44brze3Lkrki3b4PebxCy9Fplw8nTmisKo9Xxtfew08r0njyYh+uiJRAxPCXadkC9sc8g==",
       "dependencies": {
         "@polkadot/wasm-bridge": "7.3.2",
         "@polkadot/wasm-crypto-asmjs": "7.3.2",
@@ -433,7 +466,8 @@
     },
     "node_modules/@polkadot/wasm-crypto-wasm": {
       "version": "7.3.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.3.2.tgz",
+      "integrity": "sha512-15wd0EMv9IXs5Abp1ZKpKKAVyZPhATIAHfKsyoWCEFDLSOA0/K0QGOxzrAlsrdUkiKZOq7uzSIgIDgW8okx2Mw==",
       "dependencies": {
         "@polkadot/wasm-util": "7.3.2",
         "tslib": "^2.6.2"
@@ -447,7 +481,8 @@
     },
     "node_modules/@polkadot/wasm-util": {
       "version": "7.3.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.3.2.tgz",
+      "integrity": "sha512-bmD+Dxo1lTZyZNxbyPE380wd82QsX+43mgCm40boyKrRppXEyQmWT98v/Poc7chLuskYb6X8IQ6lvvK2bGR4Tg==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -459,81 +494,88 @@
       }
     },
     "node_modules/@polkadot/x-bigint": {
-      "version": "13.0.2",
-      "license": "Apache-2.0",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.1.1.tgz",
+      "integrity": "sha512-Cq4Y6fd9UWtRBZz8RX2tWEBL1IFwUtY6cL8p6HC9yhZtUR6OPjKZe6RIZQa9gSOoIuqZWd6PmtvSNGVH32yfkQ==",
       "dependencies": {
-        "@polkadot/x-global": "13.0.2",
-        "tslib": "^2.6.2"
+        "@polkadot/x-global": "13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/x-fetch": {
-      "version": "13.0.2",
-      "license": "Apache-2.0",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-13.1.1.tgz",
+      "integrity": "sha512-qA6mIUUebJbS+oWzq/EagZflmaoa9b25WvsxSFn7mCvzKngXzr+GYCY4XiDwKY/S+/pr/kvSCKZ1ia8BDqPBYQ==",
       "dependencies": {
-        "@polkadot/x-global": "13.0.2",
+        "@polkadot/x-global": "13.1.1",
         "node-fetch": "^3.3.2",
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/x-global": {
-      "version": "13.0.2",
-      "license": "Apache-2.0",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.1.1.tgz",
+      "integrity": "sha512-DViIMmmEs29Qlsp058VTg2Mn7e3/CpGazNnKJrsBa0o1Ptxl13/4Z0fjqCpNi2GB+kaOsnREzxUORrHcU+PqcQ==",
       "dependencies": {
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/x-randomvalues": {
-      "version": "13.0.2",
-      "license": "Apache-2.0",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-13.1.1.tgz",
+      "integrity": "sha512-cXj4omwbgzQQSiBtV1ZBw+XhJUU3iz/DS6ghUnGllSZEK+fGqiyaNgeFQzDY0tKjm6kYaDpvtOHR3mHsbzDuTg==",
       "dependencies": {
-        "@polkadot/x-global": "13.0.2",
-        "tslib": "^2.6.2"
+        "@polkadot/x-global": "13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "13.0.2",
+        "@polkadot/util": "13.1.1",
         "@polkadot/wasm-util": "*"
       }
     },
     "node_modules/@polkadot/x-textdecoder": {
-      "version": "13.0.2",
-      "license": "Apache-2.0",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-13.1.1.tgz",
+      "integrity": "sha512-LpZ9KYc6HdBH+i86bCmun4g4GWMiWN/1Pzs0hNdanlQMfqp3UGzl1Dqp0nozMvjWAlvyG7ip235VgNMd8HEbqg==",
       "dependencies": {
-        "@polkadot/x-global": "13.0.2",
-        "tslib": "^2.6.2"
+        "@polkadot/x-global": "13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/x-textencoder": {
-      "version": "13.0.2",
-      "license": "Apache-2.0",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-13.1.1.tgz",
+      "integrity": "sha512-w1mT15B9ptN5CJNgN/A0CmBqD5y9OePjBdU6gmAd8KRhwXCF0MTBKcEZk1dHhXiXtX+28ULJWLrfefC5gxy69Q==",
       "dependencies": {
-        "@polkadot/x-global": "13.0.2",
-        "tslib": "^2.6.2"
+        "@polkadot/x-global": "13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/x-ws": {
-      "version": "13.0.2",
-      "license": "Apache-2.0",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-13.1.1.tgz",
+      "integrity": "sha512-E/xFmJTiFzu+IK5M3/8W/9fnvNJFelcnunPv/IgO6UST94SDaTsN/Gbeb6SqPb6CsrTHRl3WD+AZ3ErGGwQfEA==",
       "dependencies": {
-        "@polkadot/x-global": "13.0.2",
-        "tslib": "^2.6.2",
+        "@polkadot/x-global": "13.1.1",
+        "tslib": "^2.7.0",
         "ws": "^8.16.0"
       },
       "engines": {
@@ -541,15 +583,18 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.1.7",
-      "license": "MIT",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@substrate/connect": {
       "version": "0.8.11",
-      "license": "GPL-3.0-only",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.8.11.tgz",
+      "integrity": "sha512-ofLs1PAO9AtDdPbdyTYj217Pe+lBfTLltdHDs3ds8no0BseoLeAGxpz1mHfi7zB4IxI3YyAiLjH6U8cw4pj4Nw==",
+      "deprecated": "versions below 1.x are no longer maintained",
       "optional": true,
       "dependencies": {
         "@substrate/connect-extension-protocol": "^2.0.0",
@@ -559,18 +604,21 @@
       }
     },
     "node_modules/@substrate/connect-extension-protocol": {
-      "version": "2.0.0",
-      "license": "GPL-3.0-only",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-2.1.0.tgz",
+      "integrity": "sha512-Wz5Cbn6S6P4vWfHyrsnPW7g15IAViMaXCk+jYkq4nNEMmzPtTKIEbtxrdDMBKrouOFtYKKp0znx5mh9KTCNqlA==",
       "optional": true
     },
     "node_modules/@substrate/connect-known-chains": {
-      "version": "1.3.0",
-      "license": "GPL-3.0-only",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-known-chains/-/connect-known-chains-1.4.1.tgz",
+      "integrity": "sha512-WlFKGEE3naIa7iTyy7hJ0RV0dyGpP7Zic1Z8sXr4bJmSEzZoHcfLRbM1D3T+zFAaitffVCu6k55Vj+CFzMPw1Q==",
       "optional": true
     },
     "node_modules/@substrate/light-client-extension-helpers": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@substrate/light-client-extension-helpers/-/light-client-extension-helpers-1.0.0.tgz",
+      "integrity": "sha512-TdKlni1mBBZptOaeVrKnusMg/UBpWUORNDv5fdCaJklP4RJiFOzBCrzC+CyVI5kQzsXBisZ+2pXm+rIjS38kHg==",
       "optional": true,
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "^0.0.1",
@@ -587,35 +635,44 @@
     },
     "node_modules/@substrate/ss58-registry": {
       "version": "1.50.0",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.50.0.tgz",
+      "integrity": "sha512-mkmlMlcC+MSd9rA+PN8ljGAm5fVZskvVwkXIsbx4NFwaT8kt38r7e9cyDWscG3z2Zn40POviZvEMrJSk+r2SgQ=="
     },
     "node_modules/@types/bn.js": {
-      "version": "5.1.5",
-      "license": "MIT",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.6.tgz",
+      "integrity": "sha512-Xh8vSwUeMKeYYrj3cX4lGQgFSF/N03r+tv4AiLl1SucqV+uTQpxRcnM8AkXKHwYP9ZPXOYXRr2KPXpVlIvqh9w==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
-      "version": "20.5.0",
-      "license": "MIT"
+      "version": "22.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.6.1.tgz",
+      "integrity": "sha512-V48tCfcKb/e6cVUigLAaJDAILdMP0fUW6BidkPK4GpGjXcfbnoHasCZDwz3N3yVt5we2RHm4XTQCpv0KJz9zqw==",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "engines": {
         "node": ">= 12"
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "license": "MIT",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -628,10 +685,13 @@
     },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
       "funding": [
         {
           "type": "github",
@@ -642,7 +702,6 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -653,7 +712,8 @@
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -663,22 +723,26 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "node_modules/mock-socket": {
       "version": "9.3.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
+      "integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "license": "MIT"
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nock": {
       "version": "13.5.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.5.tgz",
+      "integrity": "sha512-XKYnqUrCwXC8DGG1xX4YH5yNIrlh9c065uaMZZHUoeUUINTOyt+x/G+ezYk0Ft6ExSREVIs+qBJDK503viTfFA==",
       "dependencies": {
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
@@ -690,6 +754,8 @@
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "funding": [
         {
           "type": "github",
@@ -700,14 +766,14 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
       "version": "3.3.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -723,49 +789,57 @@
     },
     "node_modules/propagate": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/rxjs": {
       "version": "7.8.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "2.6.1",
-      "license": "0BSD"
-    },
     "node_modules/scale-ts": {
       "version": "1.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/scale-ts/-/scale-ts-1.6.0.tgz",
+      "integrity": "sha512-Ja5VCjNZR8TGKhUumy9clVVxcDpM+YFjAnkMuwQy68Hixio3VRRvWdE3g8T/yC+HXA0ZDQl2TGyUmtmbcVl40Q==",
       "optional": true
     },
     "node_modules/smoldot": {
       "version": "2.0.26",
-      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.26.tgz",
+      "integrity": "sha512-F+qYmH4z2s2FK+CxGj8moYcd1ekSIKH8ywkdqlOz88Dat35iB1DIYL11aILN46YSGMzQW/lbJNS307zBSDN5Ig==",
       "optional": true,
       "dependencies": {
         "ws": "^8.8.1"
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "license": "0BSD"
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/ws": {
       "version": "8.18.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/scripts/js/onboard/package.json
+++ b/scripts/js/onboard/package.json
@@ -15,8 +15,8 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@polkadot/api": "^12.4.2",
-    "@polkadot/util": "^13.0.2",
-    "@polkadot/util-crypto": "^13.0.2"
+    "@polkadot/api": "^13.2.1",
+    "@polkadot/util": "^13.1.1",
+    "@polkadot/util-crypto": "^13.1.1"
   }
 }

--- a/tools/genesis-data/package-lock.json
+++ b/tools/genesis-data/package-lock.json
@@ -9,26 +9,29 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/api": "^12.1.1"
+        "@polkadot/api": "^13.2.1"
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
-      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
+      "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
       "dependencies": {
-        "@noble/hashes": "1.4.0"
+        "@noble/hashes": "1.5.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -41,349 +44,353 @@
       "optional": true
     },
     "node_modules/@polkadot-api/json-rpc-provider-proxy": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider-proxy/-/json-rpc-provider-proxy-0.0.1.tgz",
-      "integrity": "sha512-gmVDUP8LpCH0BXewbzqXF2sdHddq1H1q+XrAW2of+KZj4woQkIGBRGTJHeBEVHe30EB+UejR1N2dT4PO/RvDdg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider-proxy/-/json-rpc-provider-proxy-0.1.0.tgz",
+      "integrity": "sha512-8GSFE5+EF73MCuLQm8tjrbCqlgclcHBSRaswvXziJ0ZW7iw3UEMsKkkKvELayWyBuOPa2T5i1nj6gFOeIsqvrg==",
       "optional": true
     },
     "node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.0.1.tgz",
-      "integrity": "sha512-GCI78BHDzXAF/L2pZD6Aod/yl82adqQ7ftNmKg51ixRL02JpWUA+SpUKTJE5MY1p8kiJJIo09P2um24SiJHxNA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.3.2.tgz",
+      "integrity": "sha512-TKpfoT6vTb+513KDzMBTfCb/ORdgRnsS3TDFpOhAhZ08ikvK+hjHMt5plPiAX/OWkm1Wc9I3+K6W0hX5Ab7MVg==",
       "optional": true,
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.0.1",
-        "@polkadot-api/utils": "0.0.1"
+        "@polkadot-api/substrate-bindings": "0.6.0",
+        "@polkadot-api/utils": "0.1.0"
       }
     },
     "node_modules/@polkadot-api/observable-client": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.1.0.tgz",
-      "integrity": "sha512-GBCGDRztKorTLna/unjl/9SWZcRmvV58o9jwU2Y038VuPXZcr01jcw/1O3x+yeAuwyGzbucI/mLTDa1QoEml3A==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.3.2.tgz",
+      "integrity": "sha512-HGgqWgEutVyOBXoGOPp4+IAq6CNdK/3MfQJmhCJb8YaJiaK4W6aRGrdQuQSTPHfERHCARt9BrOmEvTXAT257Ug==",
       "optional": true,
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.0.1",
-        "@polkadot-api/substrate-bindings": "0.0.1",
-        "@polkadot-api/substrate-client": "0.0.1",
-        "@polkadot-api/utils": "0.0.1"
+        "@polkadot-api/metadata-builders": "0.3.2",
+        "@polkadot-api/substrate-bindings": "0.6.0",
+        "@polkadot-api/utils": "0.1.0"
       },
       "peerDependencies": {
+        "@polkadot-api/substrate-client": "0.1.4",
         "rxjs": ">=7.8.0"
       }
     },
     "node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.0.1.tgz",
-      "integrity": "sha512-bAe7a5bOPnuFVmpv7y4BBMRpNTnMmE0jtTqRUw/+D8ZlEHNVEJQGr4wu3QQCl7k1GnSV1wfv3mzIbYjErEBocg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.6.0.tgz",
+      "integrity": "sha512-lGuhE74NA1/PqdN7fKFdE5C1gNYX357j1tWzdlPXI0kQ7h3kN0zfxNOpPUN7dIrPcOFZ6C0tRRVrBylXkI6xPw==",
       "optional": true,
       "dependencies": {
         "@noble/hashes": "^1.3.1",
-        "@polkadot-api/utils": "0.0.1",
+        "@polkadot-api/utils": "0.1.0",
         "@scure/base": "^1.1.1",
         "scale-ts": "^1.6.0"
       }
     },
     "node_modules/@polkadot-api/substrate-client": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-client/-/substrate-client-0.0.1.tgz",
-      "integrity": "sha512-9Bg9SGc3AwE+wXONQoW8GC00N3v6lCZLW74HQzqB6ROdcm5VAHM4CB/xRzWSUF9CXL78ugiwtHx3wBcpx4H4Wg==",
-      "optional": true
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-client/-/substrate-client-0.1.4.tgz",
+      "integrity": "sha512-MljrPobN0ZWTpn++da9vOvt+Ex+NlqTlr/XT7zi9sqPtDJiQcYl+d29hFAgpaeTqbeQKZwz3WDE9xcEfLE8c5A==",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/json-rpc-provider": "0.0.1",
+        "@polkadot-api/utils": "0.1.0"
+      }
     },
     "node_modules/@polkadot-api/utils": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/utils/-/utils-0.0.1.tgz",
-      "integrity": "sha512-3j+pRmlF9SgiYDabSdZsBSsN5XHbpXOAce1lWj56IEEaFZVjsiCaxDOA7C9nCcgfVXuvnbxqqEGQvnY+QfBAUw==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/utils/-/utils-0.1.0.tgz",
+      "integrity": "sha512-MXzWZeuGxKizPx2Xf/47wx9sr/uxKw39bVJUptTJdsaQn/TGq+z310mHzf1RCGvC1diHM8f593KrnDgc9oNbJA==",
       "optional": true
     },
     "node_modules/@polkadot/api": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-12.1.1.tgz",
-      "integrity": "sha512-XvX1gRUsnHDkEARBS1TAFCXncp6YABf/NCtOBt8FohokSzvB6Kxrcb6zurMbUm2piOdjgW5xsG3TCDRw6vACLA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-13.2.1.tgz",
+      "integrity": "sha512-QvgKD3/q6KIU3ZuNYFJUNc6B8bGBoqeMF+iaPxJn3Twhh4iVD5XIymD5fVszSqiL1uPXMhzcWecjwE8rDidBoQ==",
       "dependencies": {
-        "@polkadot/api-augment": "12.1.1",
-        "@polkadot/api-base": "12.1.1",
-        "@polkadot/api-derive": "12.1.1",
-        "@polkadot/keyring": "^12.6.2",
-        "@polkadot/rpc-augment": "12.1.1",
-        "@polkadot/rpc-core": "12.1.1",
-        "@polkadot/rpc-provider": "12.1.1",
-        "@polkadot/types": "12.1.1",
-        "@polkadot/types-augment": "12.1.1",
-        "@polkadot/types-codec": "12.1.1",
-        "@polkadot/types-create": "12.1.1",
-        "@polkadot/types-known": "12.1.1",
-        "@polkadot/util": "^12.6.2",
-        "@polkadot/util-crypto": "^12.6.2",
+        "@polkadot/api-augment": "13.2.1",
+        "@polkadot/api-base": "13.2.1",
+        "@polkadot/api-derive": "13.2.1",
+        "@polkadot/keyring": "^13.1.1",
+        "@polkadot/rpc-augment": "13.2.1",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/rpc-provider": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-augment": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/types-create": "13.2.1",
+        "@polkadot/types-known": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "@polkadot/util-crypto": "^13.1.1",
         "eventemitter3": "^5.0.1",
         "rxjs": "^7.8.1",
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/api-augment": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-12.1.1.tgz",
-      "integrity": "sha512-x2cI4mt4y2DZ8b8BoxchlkkpdmvhmOqCLr7IHPcQGaHsA/oLYSgZk8YSvUFb6+W3WjnIZiNMzv/+UB9jQuGQ2Q==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-13.2.1.tgz",
+      "integrity": "sha512-NTkI+/Hm48eWc/4Ojh/5elxnjnow5ptXK97IZdkWAe7mWi9hJR05Uq5lGt/T/57E9LSRWEuYje8cIDS3jbbAAw==",
       "dependencies": {
-        "@polkadot/api-base": "12.1.1",
-        "@polkadot/rpc-augment": "12.1.1",
-        "@polkadot/types": "12.1.1",
-        "@polkadot/types-augment": "12.1.1",
-        "@polkadot/types-codec": "12.1.1",
-        "@polkadot/util": "^12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/api-base": "13.2.1",
+        "@polkadot/rpc-augment": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-augment": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/api-base": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-12.1.1.tgz",
-      "integrity": "sha512-/zLnekv5uFnjzYWhjUf6m0WOJorA0Qm/CWg7z6V+INnacDmVD+WIgYW+XLka90KXpW92sN5ycZEdcQGKBxSJOg==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-13.2.1.tgz",
+      "integrity": "sha512-00twdIjTjzdYNdU19i2YKLoWBmf2Yr6b3qrvqIVScHipUkKMbfFBgoPRB5FtcviBbEvLurgfyzHklwnrbWo8GQ==",
       "dependencies": {
-        "@polkadot/rpc-core": "12.1.1",
-        "@polkadot/types": "12.1.1",
-        "@polkadot/util": "^12.6.2",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/util": "^13.1.1",
         "rxjs": "^7.8.1",
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/api-derive": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-12.1.1.tgz",
-      "integrity": "sha512-VMwHcQY8gU/fhwgRICs9/EwTZVMSWW9Gf1ktwsWQmNM1RnrR6oN4/hvzsQor4Be/mC93w2f8bX/71QVmOgL5NA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-13.2.1.tgz",
+      "integrity": "sha512-npxvS0kYcSFqmYv2G8QKWAJwFhIv/MBuGU0bV7cGP9K1A3j2Do3yYjvN1dTtY20jBavWNwmWFdXBV6/TRRsgmg==",
       "dependencies": {
-        "@polkadot/api": "12.1.1",
-        "@polkadot/api-augment": "12.1.1",
-        "@polkadot/api-base": "12.1.1",
-        "@polkadot/rpc-core": "12.1.1",
-        "@polkadot/types": "12.1.1",
-        "@polkadot/types-codec": "12.1.1",
-        "@polkadot/util": "^12.6.2",
-        "@polkadot/util-crypto": "^12.6.2",
+        "@polkadot/api": "13.2.1",
+        "@polkadot/api-augment": "13.2.1",
+        "@polkadot/api-base": "13.2.1",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "@polkadot/util-crypto": "^13.1.1",
         "rxjs": "^7.8.1",
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/keyring": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.6.2.tgz",
-      "integrity": "sha512-O3Q7GVmRYm8q7HuB3S0+Yf/q/EB2egKRRU3fv9b3B7V+A52tKzA+vIwEmNVaD1g5FKW9oB97rmpggs0zaKFqHw==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-13.1.1.tgz",
+      "integrity": "sha512-Wm+9gn946GIPjGzvueObLGBBS9s541HE6mvKdWGEmPFMzH93ESN931RZlOd67my5MWryiSP05h5SHTp7bSaQTA==",
       "dependencies": {
-        "@polkadot/util": "12.6.2",
-        "@polkadot/util-crypto": "12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/util": "13.1.1",
+        "@polkadot/util-crypto": "13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "12.6.2",
-        "@polkadot/util-crypto": "12.6.2"
+        "@polkadot/util": "13.1.1",
+        "@polkadot/util-crypto": "13.1.1"
       }
     },
     "node_modules/@polkadot/networks": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.6.2.tgz",
-      "integrity": "sha512-1oWtZm1IvPWqvMrldVH6NI2gBoCndl5GEwx7lAuQWGr7eNL+6Bdc5K3Z9T0MzFvDGoi2/CBqjX9dRKo39pDC/w==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-13.1.1.tgz",
+      "integrity": "sha512-eEQ4+Mfl1xFtApeU5PdXZ2XBhxNSvUz9yW+YQVGUCkXRjWFbqNRsTOYWGd9uFbiAOXiiiXbtqfZpxSDzIm4XOg==",
       "dependencies": {
-        "@polkadot/util": "12.6.2",
-        "@substrate/ss58-registry": "^1.44.0",
-        "tslib": "^2.6.2"
+        "@polkadot/util": "13.1.1",
+        "@substrate/ss58-registry": "^1.50.0",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/rpc-augment": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-12.1.1.tgz",
-      "integrity": "sha512-oDPn070l94pppXbuVk75BVsYgupdV8ndmslnUKWpPlfOeAU5SaBu4jMkj3eAi3VH0ersUpmlp1UuYN612//h8w==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-13.2.1.tgz",
+      "integrity": "sha512-HkndaAJPR1fi2xrzvP3q4g48WUCb26btGTeg1AKG9FGx9P2dgtpaPRmbMitmgVSzzRurrkxf3Meip8nC7BwDeg==",
       "dependencies": {
-        "@polkadot/rpc-core": "12.1.1",
-        "@polkadot/types": "12.1.1",
-        "@polkadot/types-codec": "12.1.1",
-        "@polkadot/util": "^12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/rpc-core": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-12.1.1.tgz",
-      "integrity": "sha512-NB4BZo9RdAZPBfZ11NoujB8+SDkDgvlrSiiv9FPMhfvTJo0Sr5FAq0Wd2aSC4D/6qbt5e89CHOW+0gBEm9d6dw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-13.2.1.tgz",
+      "integrity": "sha512-hy0GksUlb/TfQ38m3ysIWj3qD+rIsyCdxx8Ug5rIx1u0odv86NZ7nTqtH066Ct2riVaPBgBkObFnlpDWTJ6auA==",
       "dependencies": {
-        "@polkadot/rpc-augment": "12.1.1",
-        "@polkadot/rpc-provider": "12.1.1",
-        "@polkadot/types": "12.1.1",
-        "@polkadot/util": "^12.6.2",
+        "@polkadot/rpc-augment": "13.2.1",
+        "@polkadot/rpc-provider": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/util": "^13.1.1",
         "rxjs": "^7.8.1",
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/rpc-provider": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-12.1.1.tgz",
-      "integrity": "sha512-nDr0Qb5sIzTTx6qmgr9ibNcQs/VDoPzZ+49kcltf0A6BdSytGy532Yhf2A158aD41324V9YPAzxVRLxZyJzhkw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-13.2.1.tgz",
+      "integrity": "sha512-bbMVYHTNFUa89aY3UQ1hFYD+dP+v+0vhjsnHYYlv37rSUTqOGqW91rkHd63xYCpLAimFt7KRw8xR+SMSYiuDjw==",
       "dependencies": {
-        "@polkadot/keyring": "^12.6.2",
-        "@polkadot/types": "12.1.1",
-        "@polkadot/types-support": "12.1.1",
-        "@polkadot/util": "^12.6.2",
-        "@polkadot/util-crypto": "^12.6.2",
-        "@polkadot/x-fetch": "^12.6.2",
-        "@polkadot/x-global": "^12.6.2",
-        "@polkadot/x-ws": "^12.6.2",
+        "@polkadot/keyring": "^13.1.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-support": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "@polkadot/util-crypto": "^13.1.1",
+        "@polkadot/x-fetch": "^13.1.1",
+        "@polkadot/x-global": "^13.1.1",
+        "@polkadot/x-ws": "^13.1.1",
         "eventemitter3": "^5.0.1",
         "mock-socket": "^9.3.1",
-        "nock": "^13.5.0",
-        "tslib": "^2.6.2"
+        "nock": "^13.5.4",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@substrate/connect": "0.8.10"
+        "@substrate/connect": "0.8.11"
       }
     },
     "node_modules/@polkadot/types": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-12.1.1.tgz",
-      "integrity": "sha512-+b8v7ORjL20r6VvdWL/fPTHmDXtfAfqkQQxBB6exxOhqrnJfnhAYQjJomKcyj1VMTQiyyR9FBAc7vVvTEFX2ew==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-13.2.1.tgz",
+      "integrity": "sha512-5yQ0mHMNvwgXeHQ1RZOuHaeak3utAdcBqCpHoagnYrAnGHqtO7kg7YLtT4LkFw2nwL85axu8tOQMv6/3kpFy9w==",
       "dependencies": {
-        "@polkadot/keyring": "^12.6.2",
-        "@polkadot/types-augment": "12.1.1",
-        "@polkadot/types-codec": "12.1.1",
-        "@polkadot/types-create": "12.1.1",
-        "@polkadot/util": "^12.6.2",
-        "@polkadot/util-crypto": "^12.6.2",
+        "@polkadot/keyring": "^13.1.1",
+        "@polkadot/types-augment": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/types-create": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "@polkadot/util-crypto": "^13.1.1",
         "rxjs": "^7.8.1",
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/types-augment": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-12.1.1.tgz",
-      "integrity": "sha512-HdzjaXapcmNAdT6TWJOuv124PTKbAf5+5JldQ7oPZFaCEhaOTazZYiZ27nqLaj0l4rG7wWzFMiGqjbHwAvtmlg==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-13.2.1.tgz",
+      "integrity": "sha512-FpV7/2kIJmmswRmwUbp41lixdNX15olueUjHnSweFk0xEn2Ur43oC0Y3eU3Ab7Y5gPJpceMCfwYz+PjCUGedDA==",
       "dependencies": {
-        "@polkadot/types": "12.1.1",
-        "@polkadot/types-codec": "12.1.1",
-        "@polkadot/util": "^12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/types-codec": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-12.1.1.tgz",
-      "integrity": "sha512-Ob3nFptHT4dDvGc/3l4dBXmvsI3wDWS2oCOxACA+hYWufnlTIQ4M4sHI4kSBQvDoEmaFt8P2Be4SmtyT0VSd1w==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-13.2.1.tgz",
+      "integrity": "sha512-tFAzzS8sMYItoD5a91sFMD+rskWyv4WjSmUZaj0Y4OfLtDAiQvgO0KncdGJIB6D+zZ/T7khpgsv/CZbN3YnezA==",
       "dependencies": {
-        "@polkadot/util": "^12.6.2",
-        "@polkadot/x-bigint": "^12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/util": "^13.1.1",
+        "@polkadot/x-bigint": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/types-create": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-12.1.1.tgz",
-      "integrity": "sha512-K/I4vCnmI7IbtQeURiRMONDqesIVcZp16KEduBcbJm/RWDj0D3mr71066Yr8OhrhteLvULJpViy7EK4ynPvmSw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-13.2.1.tgz",
+      "integrity": "sha512-O/WKdsrNuMaZLf+XRCdum2xJYs5OKC6N3EMPF5Uhg10b80Y/hQCbzA/iWd3/aMNDLUA5XWhixwzJdrZWIMVIzg==",
       "dependencies": {
-        "@polkadot/types-codec": "12.1.1",
-        "@polkadot/util": "^12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/types-known": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-12.1.1.tgz",
-      "integrity": "sha512-4YxY7tB+BVX6k3ubrToYKyh2Jb4QvoLvzwNSGSjyj0RGwiQCu8anFGIzYdaUJ2iQlhLFb6P4AZWykVvhrXGmqg==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-13.2.1.tgz",
+      "integrity": "sha512-uz3c4/IvspLpgN8q15A+QH8KWFauzcrV3RfLFlMP2BkkF5qpOwNeP7c4U8j0CZGQySqBsJRCGWmgBXrXg669KA==",
       "dependencies": {
-        "@polkadot/networks": "^12.6.2",
-        "@polkadot/types": "12.1.1",
-        "@polkadot/types-codec": "12.1.1",
-        "@polkadot/types-create": "12.1.1",
-        "@polkadot/util": "^12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/networks": "^13.1.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/types-create": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/types-support": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-12.1.1.tgz",
-      "integrity": "sha512-mLXrbj0maKFWqV1+4QRzaNnZyV/rAQW0XSrIzfIZn//zSRSIUaXaVAZ62uzgdmzXXFH2qD3hpNlmvmjcEMm2Qg==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-13.2.1.tgz",
+      "integrity": "sha512-jSbbUTXU+yZJQPRAWmxaDoe4NRO6SjpZPzBIbpuiadx1slON8XB80fVYIGBXuM2xRVrNrB6fCjyCTG7Razj6Hg==",
       "dependencies": {
-        "@polkadot/util": "^12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/util": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/util": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.6.2.tgz",
-      "integrity": "sha512-l8TubR7CLEY47240uki0TQzFvtnxFIO7uI/0GoWzpYD/O62EIAMRsuY01N4DuwgKq2ZWD59WhzsLYmA5K6ksdw==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.1.1.tgz",
+      "integrity": "sha512-M4iQ5Um8tFdDmD7a96nPzfrEt+kxyWOqQDPqXyaax4QBnq/WCbq0jo8IO61uz55mdMQnGZvq8jd8uge4V6JzzQ==",
       "dependencies": {
-        "@polkadot/x-bigint": "12.6.2",
-        "@polkadot/x-global": "12.6.2",
-        "@polkadot/x-textdecoder": "12.6.2",
-        "@polkadot/x-textencoder": "12.6.2",
+        "@polkadot/x-bigint": "13.1.1",
+        "@polkadot/x-global": "13.1.1",
+        "@polkadot/x-textdecoder": "13.1.1",
+        "@polkadot/x-textencoder": "13.1.1",
         "@types/bn.js": "^5.1.5",
         "bn.js": "^5.2.1",
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/util-crypto": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.6.2.tgz",
-      "integrity": "sha512-FEWI/dJ7wDMNN1WOzZAjQoIcCP/3vz3wvAp5QQm+lOrzOLj0iDmaIGIcBkz8HVm3ErfSe/uKP0KS4jgV/ib+Mg==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-13.1.1.tgz",
+      "integrity": "sha512-FG68rrLPdfLcscEyH10vnGkakM4O2lqr71S3GDhgc9WXaS8y9jisLgMPg8jbMHiQBJ3iKYkmtPKiLBowRslj2w==",
       "dependencies": {
         "@noble/curves": "^1.3.0",
         "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "12.6.2",
-        "@polkadot/util": "12.6.2",
+        "@polkadot/networks": "13.1.1",
+        "@polkadot/util": "13.1.1",
         "@polkadot/wasm-crypto": "^7.3.2",
         "@polkadot/wasm-util": "^7.3.2",
-        "@polkadot/x-bigint": "12.6.2",
-        "@polkadot/x-randomvalues": "12.6.2",
-        "@scure/base": "^1.1.5",
-        "tslib": "^2.6.2"
+        "@polkadot/x-bigint": "13.1.1",
+        "@polkadot/x-randomvalues": "13.1.1",
+        "@scure/base": "^1.1.7",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "12.6.2"
+        "@polkadot/util": "13.1.1"
       }
     },
     "node_modules/@polkadot/wasm-bridge": {
@@ -485,139 +492,139 @@
       }
     },
     "node_modules/@polkadot/x-bigint": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.6.2.tgz",
-      "integrity": "sha512-HSIk60uFPX4GOFZSnIF7VYJz7WZA7tpFJsne7SzxOooRwMTWEtw3fUpFy5cYYOeLh17/kHH1Y7SVcuxzVLc74Q==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.1.1.tgz",
+      "integrity": "sha512-Cq4Y6fd9UWtRBZz8RX2tWEBL1IFwUtY6cL8p6HC9yhZtUR6OPjKZe6RIZQa9gSOoIuqZWd6PmtvSNGVH32yfkQ==",
       "dependencies": {
-        "@polkadot/x-global": "12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/x-global": "13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/x-fetch": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.6.2.tgz",
-      "integrity": "sha512-8wM/Z9JJPWN1pzSpU7XxTI1ldj/AfC8hKioBlUahZ8gUiJaOF7K9XEFCrCDLis/A1BoOu7Ne6WMx/vsJJIbDWw==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-13.1.1.tgz",
+      "integrity": "sha512-qA6mIUUebJbS+oWzq/EagZflmaoa9b25WvsxSFn7mCvzKngXzr+GYCY4XiDwKY/S+/pr/kvSCKZ1ia8BDqPBYQ==",
       "dependencies": {
-        "@polkadot/x-global": "12.6.2",
+        "@polkadot/x-global": "13.1.1",
         "node-fetch": "^3.3.2",
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/x-global": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.6.2.tgz",
-      "integrity": "sha512-a8d6m+PW98jmsYDtAWp88qS4dl8DyqUBsd0S+WgyfSMtpEXu6v9nXDgPZgwF5xdDvXhm+P0ZfVkVTnIGrScb5g==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.1.1.tgz",
+      "integrity": "sha512-DViIMmmEs29Qlsp058VTg2Mn7e3/CpGazNnKJrsBa0o1Ptxl13/4Z0fjqCpNi2GB+kaOsnREzxUORrHcU+PqcQ==",
       "dependencies": {
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/x-randomvalues": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.6.2.tgz",
-      "integrity": "sha512-Vr8uG7rH2IcNJwtyf5ebdODMcr0XjoCpUbI91Zv6AlKVYOGKZlKLYJHIwpTaKKB+7KPWyQrk4Mlym/rS7v9feg==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-13.1.1.tgz",
+      "integrity": "sha512-cXj4omwbgzQQSiBtV1ZBw+XhJUU3iz/DS6ghUnGllSZEK+fGqiyaNgeFQzDY0tKjm6kYaDpvtOHR3mHsbzDuTg==",
       "dependencies": {
-        "@polkadot/x-global": "12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/x-global": "13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "12.6.2",
+        "@polkadot/util": "13.1.1",
         "@polkadot/wasm-util": "*"
       }
     },
     "node_modules/@polkadot/x-textdecoder": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.6.2.tgz",
-      "integrity": "sha512-M1Bir7tYvNappfpFWXOJcnxUhBUFWkUFIdJSyH0zs5LmFtFdbKAeiDXxSp2Swp5ddOZdZgPac294/o2TnQKN1w==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-13.1.1.tgz",
+      "integrity": "sha512-LpZ9KYc6HdBH+i86bCmun4g4GWMiWN/1Pzs0hNdanlQMfqp3UGzl1Dqp0nozMvjWAlvyG7ip235VgNMd8HEbqg==",
       "dependencies": {
-        "@polkadot/x-global": "12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/x-global": "13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/x-textencoder": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.6.2.tgz",
-      "integrity": "sha512-4N+3UVCpI489tUJ6cv3uf0PjOHvgGp9Dl+SZRLgFGt9mvxnvpW/7+XBADRMtlG4xi5gaRK7bgl5bmY6OMDsNdw==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-13.1.1.tgz",
+      "integrity": "sha512-w1mT15B9ptN5CJNgN/A0CmBqD5y9OePjBdU6gmAd8KRhwXCF0MTBKcEZk1dHhXiXtX+28ULJWLrfefC5gxy69Q==",
       "dependencies": {
-        "@polkadot/x-global": "12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/x-global": "13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/x-ws": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.6.2.tgz",
-      "integrity": "sha512-cGZWo7K5eRRQCRl2LrcyCYsrc3lRbTlixZh3AzgU8uX4wASVGRlNWi/Hf4TtHNe1ExCDmxabJzdIsABIfrr7xw==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-13.1.1.tgz",
+      "integrity": "sha512-E/xFmJTiFzu+IK5M3/8W/9fnvNJFelcnunPv/IgO6UST94SDaTsN/Gbeb6SqPb6CsrTHRl3WD+AZ3ErGGwQfEA==",
       "dependencies": {
-        "@polkadot/x-global": "12.6.2",
-        "tslib": "^2.6.2",
-        "ws": "^8.15.1"
+        "@polkadot/x-global": "13.1.1",
+        "tslib": "^2.7.0",
+        "ws": "^8.16.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.7.tgz",
-      "integrity": "sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@substrate/connect": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.8.10.tgz",
-      "integrity": "sha512-DIyQ13DDlXqVFnLV+S6/JDgiGowVRRrh18kahieJxhgvzcWicw5eLc6jpfQ0moVVLBYkO7rctB5Wreldwpva8w==",
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.8.11.tgz",
+      "integrity": "sha512-ofLs1PAO9AtDdPbdyTYj217Pe+lBfTLltdHDs3ds8no0BseoLeAGxpz1mHfi7zB4IxI3YyAiLjH6U8cw4pj4Nw==",
       "deprecated": "versions below 1.x are no longer maintained",
       "optional": true,
       "dependencies": {
         "@substrate/connect-extension-protocol": "^2.0.0",
-        "@substrate/connect-known-chains": "^1.1.4",
-        "@substrate/light-client-extension-helpers": "^0.0.6",
-        "smoldot": "2.0.22"
+        "@substrate/connect-known-chains": "^1.1.5",
+        "@substrate/light-client-extension-helpers": "^1.0.0",
+        "smoldot": "2.0.26"
       }
     },
     "node_modules/@substrate/connect-extension-protocol": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-2.0.0.tgz",
-      "integrity": "sha512-nKu8pDrE3LNCEgJjZe1iGXzaD6OSIDD4Xzz/yo4KO9mQ6LBvf49BVrt4qxBFGL6++NneLiWUZGoh+VSd4PyVIg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-2.1.0.tgz",
+      "integrity": "sha512-Wz5Cbn6S6P4vWfHyrsnPW7g15IAViMaXCk+jYkq4nNEMmzPtTKIEbtxrdDMBKrouOFtYKKp0znx5mh9KTCNqlA==",
       "optional": true
     },
     "node_modules/@substrate/connect-known-chains": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@substrate/connect-known-chains/-/connect-known-chains-1.1.8.tgz",
-      "integrity": "sha512-W0Cpnk//LoMTu5BGDCRRg5NHFR2aZ9OJtLGSgRyq1RP39dQGpoVZIgNC6z+SWRzlmOz3gIgkUCwGvOKVt2BabA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-known-chains/-/connect-known-chains-1.4.1.tgz",
+      "integrity": "sha512-WlFKGEE3naIa7iTyy7hJ0RV0dyGpP7Zic1Z8sXr4bJmSEzZoHcfLRbM1D3T+zFAaitffVCu6k55Vj+CFzMPw1Q==",
       "optional": true
     },
     "node_modules/@substrate/light-client-extension-helpers": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@substrate/light-client-extension-helpers/-/light-client-extension-helpers-0.0.6.tgz",
-      "integrity": "sha512-girltEuxQ1BvkJWmc8JJlk4ZxnlGXc/wkLcNguhY+UoDEMBK0LsdtfzQKIfrIehi4QdeSBlFEFBoI4RqPmsZzA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@substrate/light-client-extension-helpers/-/light-client-extension-helpers-1.0.0.tgz",
+      "integrity": "sha512-TdKlni1mBBZptOaeVrKnusMg/UBpWUORNDv5fdCaJklP4RJiFOzBCrzC+CyVI5kQzsXBisZ+2pXm+rIjS38kHg==",
       "optional": true,
       "dependencies": {
-        "@polkadot-api/json-rpc-provider": "0.0.1",
-        "@polkadot-api/json-rpc-provider-proxy": "0.0.1",
-        "@polkadot-api/observable-client": "0.1.0",
-        "@polkadot-api/substrate-client": "0.0.1",
+        "@polkadot-api/json-rpc-provider": "^0.0.1",
+        "@polkadot-api/json-rpc-provider-proxy": "^0.1.0",
+        "@polkadot-api/observable-client": "^0.3.0",
+        "@polkadot-api/substrate-client": "^0.1.2",
         "@substrate/connect-extension-protocol": "^2.0.0",
-        "@substrate/connect-known-chains": "^1.1.4",
+        "@substrate/connect-known-chains": "^1.1.5",
         "rxjs": "^7.8.1"
       },
       "peerDependencies": {
@@ -625,24 +632,24 @@
       }
     },
     "node_modules/@substrate/ss58-registry": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.49.0.tgz",
-      "integrity": "sha512-leW6Ix4LD7XgvxT7+aobPWSw+WvPcN2Rxof1rmd0mNC5t2n99k1N7UNEvz7YEFSOUeHWmKIY7F5q8KeIqYoHfA=="
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.50.0.tgz",
+      "integrity": "sha512-mkmlMlcC+MSd9rA+PN8ljGAm5fVZskvVwkXIsbx4NFwaT8kt38r7e9cyDWscG3z2Zn40POviZvEMrJSk+r2SgQ=="
     },
     "node_modules/@types/bn.js": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.5.tgz",
-      "integrity": "sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.6.tgz",
+      "integrity": "sha512-Xh8vSwUeMKeYYrj3cX4lGQgFSF/N03r+tv4AiLl1SucqV+uTQpxRcnM8AkXKHwYP9ZPXOYXRr2KPXpVlIvqh9w==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
-      "version": "20.14.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
-      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+      "version": "22.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.6.1.tgz",
+      "integrity": "sha512-V48tCfcKb/e6cVUigLAaJDAILdMP0fUW6BidkPK4GpGjXcfbnoHasCZDwz3N3yVt5we2RHm4XTQCpv0KJz9zqw==",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/bn.js": {
@@ -659,11 +666,11 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -726,14 +733,14 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nock": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
-      "integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
+      "version": "13.5.5",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.5.tgz",
+      "integrity": "sha512-XKYnqUrCwXC8DGG1xX4YH5yNIrlh9c065uaMZZHUoeUUINTOyt+x/G+ezYk0Ft6ExSREVIs+qBJDK503viTfFA==",
       "dependencies": {
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
@@ -801,23 +808,23 @@
       "optional": true
     },
     "node_modules/smoldot": {
-      "version": "2.0.22",
-      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.22.tgz",
-      "integrity": "sha512-B50vRgTY6v3baYH6uCgL15tfaag5tcS2o/P5q1OiXcKGv1axZDfz2dzzMuIkVpyMR2ug11F6EAtQlmYBQd292g==",
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.26.tgz",
+      "integrity": "sha512-F+qYmH4z2s2FK+CxGj8moYcd1ekSIKH8ywkdqlOz88Dat35iB1DIYL11aILN46YSGMzQW/lbJNS307zBSDN5Ig==",
       "optional": true,
       "dependencies": {
         "ws": "^8.8.1"
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
@@ -828,9 +835,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/tools/genesis-data/package.json
+++ b/tools/genesis-data/package.json
@@ -8,6 +8,6 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@polkadot/api": "^12.1.1"
+    "@polkadot/api": "^13.2.1"
   }
 }

--- a/tools/state-copy/package-lock.json
+++ b/tools/state-copy/package-lock.json
@@ -9,27 +9,30 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/api": "^12.1.1",
-        "@polkadot/keyring": "^12.6.2"
+        "@polkadot/api": "^13.2.1",
+        "@polkadot/keyring": "^13.1.1"
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
-      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
+      "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
       "dependencies": {
-        "@noble/hashes": "1.4.0"
+        "@noble/hashes": "1.5.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -42,349 +45,353 @@
       "optional": true
     },
     "node_modules/@polkadot-api/json-rpc-provider-proxy": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider-proxy/-/json-rpc-provider-proxy-0.0.1.tgz",
-      "integrity": "sha512-gmVDUP8LpCH0BXewbzqXF2sdHddq1H1q+XrAW2of+KZj4woQkIGBRGTJHeBEVHe30EB+UejR1N2dT4PO/RvDdg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider-proxy/-/json-rpc-provider-proxy-0.1.0.tgz",
+      "integrity": "sha512-8GSFE5+EF73MCuLQm8tjrbCqlgclcHBSRaswvXziJ0ZW7iw3UEMsKkkKvELayWyBuOPa2T5i1nj6gFOeIsqvrg==",
       "optional": true
     },
     "node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.0.1.tgz",
-      "integrity": "sha512-GCI78BHDzXAF/L2pZD6Aod/yl82adqQ7ftNmKg51ixRL02JpWUA+SpUKTJE5MY1p8kiJJIo09P2um24SiJHxNA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.3.2.tgz",
+      "integrity": "sha512-TKpfoT6vTb+513KDzMBTfCb/ORdgRnsS3TDFpOhAhZ08ikvK+hjHMt5plPiAX/OWkm1Wc9I3+K6W0hX5Ab7MVg==",
       "optional": true,
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.0.1",
-        "@polkadot-api/utils": "0.0.1"
+        "@polkadot-api/substrate-bindings": "0.6.0",
+        "@polkadot-api/utils": "0.1.0"
       }
     },
     "node_modules/@polkadot-api/observable-client": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.1.0.tgz",
-      "integrity": "sha512-GBCGDRztKorTLna/unjl/9SWZcRmvV58o9jwU2Y038VuPXZcr01jcw/1O3x+yeAuwyGzbucI/mLTDa1QoEml3A==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.3.2.tgz",
+      "integrity": "sha512-HGgqWgEutVyOBXoGOPp4+IAq6CNdK/3MfQJmhCJb8YaJiaK4W6aRGrdQuQSTPHfERHCARt9BrOmEvTXAT257Ug==",
       "optional": true,
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.0.1",
-        "@polkadot-api/substrate-bindings": "0.0.1",
-        "@polkadot-api/substrate-client": "0.0.1",
-        "@polkadot-api/utils": "0.0.1"
+        "@polkadot-api/metadata-builders": "0.3.2",
+        "@polkadot-api/substrate-bindings": "0.6.0",
+        "@polkadot-api/utils": "0.1.0"
       },
       "peerDependencies": {
+        "@polkadot-api/substrate-client": "0.1.4",
         "rxjs": ">=7.8.0"
       }
     },
     "node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.0.1.tgz",
-      "integrity": "sha512-bAe7a5bOPnuFVmpv7y4BBMRpNTnMmE0jtTqRUw/+D8ZlEHNVEJQGr4wu3QQCl7k1GnSV1wfv3mzIbYjErEBocg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.6.0.tgz",
+      "integrity": "sha512-lGuhE74NA1/PqdN7fKFdE5C1gNYX357j1tWzdlPXI0kQ7h3kN0zfxNOpPUN7dIrPcOFZ6C0tRRVrBylXkI6xPw==",
       "optional": true,
       "dependencies": {
         "@noble/hashes": "^1.3.1",
-        "@polkadot-api/utils": "0.0.1",
+        "@polkadot-api/utils": "0.1.0",
         "@scure/base": "^1.1.1",
         "scale-ts": "^1.6.0"
       }
     },
     "node_modules/@polkadot-api/substrate-client": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-client/-/substrate-client-0.0.1.tgz",
-      "integrity": "sha512-9Bg9SGc3AwE+wXONQoW8GC00N3v6lCZLW74HQzqB6ROdcm5VAHM4CB/xRzWSUF9CXL78ugiwtHx3wBcpx4H4Wg==",
-      "optional": true
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-client/-/substrate-client-0.1.4.tgz",
+      "integrity": "sha512-MljrPobN0ZWTpn++da9vOvt+Ex+NlqTlr/XT7zi9sqPtDJiQcYl+d29hFAgpaeTqbeQKZwz3WDE9xcEfLE8c5A==",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/json-rpc-provider": "0.0.1",
+        "@polkadot-api/utils": "0.1.0"
+      }
     },
     "node_modules/@polkadot-api/utils": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/utils/-/utils-0.0.1.tgz",
-      "integrity": "sha512-3j+pRmlF9SgiYDabSdZsBSsN5XHbpXOAce1lWj56IEEaFZVjsiCaxDOA7C9nCcgfVXuvnbxqqEGQvnY+QfBAUw==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/utils/-/utils-0.1.0.tgz",
+      "integrity": "sha512-MXzWZeuGxKizPx2Xf/47wx9sr/uxKw39bVJUptTJdsaQn/TGq+z310mHzf1RCGvC1diHM8f593KrnDgc9oNbJA==",
       "optional": true
     },
     "node_modules/@polkadot/api": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-12.1.1.tgz",
-      "integrity": "sha512-XvX1gRUsnHDkEARBS1TAFCXncp6YABf/NCtOBt8FohokSzvB6Kxrcb6zurMbUm2piOdjgW5xsG3TCDRw6vACLA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-13.2.1.tgz",
+      "integrity": "sha512-QvgKD3/q6KIU3ZuNYFJUNc6B8bGBoqeMF+iaPxJn3Twhh4iVD5XIymD5fVszSqiL1uPXMhzcWecjwE8rDidBoQ==",
       "dependencies": {
-        "@polkadot/api-augment": "12.1.1",
-        "@polkadot/api-base": "12.1.1",
-        "@polkadot/api-derive": "12.1.1",
-        "@polkadot/keyring": "^12.6.2",
-        "@polkadot/rpc-augment": "12.1.1",
-        "@polkadot/rpc-core": "12.1.1",
-        "@polkadot/rpc-provider": "12.1.1",
-        "@polkadot/types": "12.1.1",
-        "@polkadot/types-augment": "12.1.1",
-        "@polkadot/types-codec": "12.1.1",
-        "@polkadot/types-create": "12.1.1",
-        "@polkadot/types-known": "12.1.1",
-        "@polkadot/util": "^12.6.2",
-        "@polkadot/util-crypto": "^12.6.2",
+        "@polkadot/api-augment": "13.2.1",
+        "@polkadot/api-base": "13.2.1",
+        "@polkadot/api-derive": "13.2.1",
+        "@polkadot/keyring": "^13.1.1",
+        "@polkadot/rpc-augment": "13.2.1",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/rpc-provider": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-augment": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/types-create": "13.2.1",
+        "@polkadot/types-known": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "@polkadot/util-crypto": "^13.1.1",
         "eventemitter3": "^5.0.1",
         "rxjs": "^7.8.1",
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/api-augment": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-12.1.1.tgz",
-      "integrity": "sha512-x2cI4mt4y2DZ8b8BoxchlkkpdmvhmOqCLr7IHPcQGaHsA/oLYSgZk8YSvUFb6+W3WjnIZiNMzv/+UB9jQuGQ2Q==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-13.2.1.tgz",
+      "integrity": "sha512-NTkI+/Hm48eWc/4Ojh/5elxnjnow5ptXK97IZdkWAe7mWi9hJR05Uq5lGt/T/57E9LSRWEuYje8cIDS3jbbAAw==",
       "dependencies": {
-        "@polkadot/api-base": "12.1.1",
-        "@polkadot/rpc-augment": "12.1.1",
-        "@polkadot/types": "12.1.1",
-        "@polkadot/types-augment": "12.1.1",
-        "@polkadot/types-codec": "12.1.1",
-        "@polkadot/util": "^12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/api-base": "13.2.1",
+        "@polkadot/rpc-augment": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-augment": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/api-base": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-12.1.1.tgz",
-      "integrity": "sha512-/zLnekv5uFnjzYWhjUf6m0WOJorA0Qm/CWg7z6V+INnacDmVD+WIgYW+XLka90KXpW92sN5ycZEdcQGKBxSJOg==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-13.2.1.tgz",
+      "integrity": "sha512-00twdIjTjzdYNdU19i2YKLoWBmf2Yr6b3qrvqIVScHipUkKMbfFBgoPRB5FtcviBbEvLurgfyzHklwnrbWo8GQ==",
       "dependencies": {
-        "@polkadot/rpc-core": "12.1.1",
-        "@polkadot/types": "12.1.1",
-        "@polkadot/util": "^12.6.2",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/util": "^13.1.1",
         "rxjs": "^7.8.1",
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/api-derive": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-12.1.1.tgz",
-      "integrity": "sha512-VMwHcQY8gU/fhwgRICs9/EwTZVMSWW9Gf1ktwsWQmNM1RnrR6oN4/hvzsQor4Be/mC93w2f8bX/71QVmOgL5NA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-13.2.1.tgz",
+      "integrity": "sha512-npxvS0kYcSFqmYv2G8QKWAJwFhIv/MBuGU0bV7cGP9K1A3j2Do3yYjvN1dTtY20jBavWNwmWFdXBV6/TRRsgmg==",
       "dependencies": {
-        "@polkadot/api": "12.1.1",
-        "@polkadot/api-augment": "12.1.1",
-        "@polkadot/api-base": "12.1.1",
-        "@polkadot/rpc-core": "12.1.1",
-        "@polkadot/types": "12.1.1",
-        "@polkadot/types-codec": "12.1.1",
-        "@polkadot/util": "^12.6.2",
-        "@polkadot/util-crypto": "^12.6.2",
+        "@polkadot/api": "13.2.1",
+        "@polkadot/api-augment": "13.2.1",
+        "@polkadot/api-base": "13.2.1",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "@polkadot/util-crypto": "^13.1.1",
         "rxjs": "^7.8.1",
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/keyring": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.6.2.tgz",
-      "integrity": "sha512-O3Q7GVmRYm8q7HuB3S0+Yf/q/EB2egKRRU3fv9b3B7V+A52tKzA+vIwEmNVaD1g5FKW9oB97rmpggs0zaKFqHw==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-13.1.1.tgz",
+      "integrity": "sha512-Wm+9gn946GIPjGzvueObLGBBS9s541HE6mvKdWGEmPFMzH93ESN931RZlOd67my5MWryiSP05h5SHTp7bSaQTA==",
       "dependencies": {
-        "@polkadot/util": "12.6.2",
-        "@polkadot/util-crypto": "12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/util": "13.1.1",
+        "@polkadot/util-crypto": "13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "12.6.2",
-        "@polkadot/util-crypto": "12.6.2"
+        "@polkadot/util": "13.1.1",
+        "@polkadot/util-crypto": "13.1.1"
       }
     },
     "node_modules/@polkadot/networks": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.6.2.tgz",
-      "integrity": "sha512-1oWtZm1IvPWqvMrldVH6NI2gBoCndl5GEwx7lAuQWGr7eNL+6Bdc5K3Z9T0MzFvDGoi2/CBqjX9dRKo39pDC/w==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-13.1.1.tgz",
+      "integrity": "sha512-eEQ4+Mfl1xFtApeU5PdXZ2XBhxNSvUz9yW+YQVGUCkXRjWFbqNRsTOYWGd9uFbiAOXiiiXbtqfZpxSDzIm4XOg==",
       "dependencies": {
-        "@polkadot/util": "12.6.2",
-        "@substrate/ss58-registry": "^1.44.0",
-        "tslib": "^2.6.2"
+        "@polkadot/util": "13.1.1",
+        "@substrate/ss58-registry": "^1.50.0",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/rpc-augment": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-12.1.1.tgz",
-      "integrity": "sha512-oDPn070l94pppXbuVk75BVsYgupdV8ndmslnUKWpPlfOeAU5SaBu4jMkj3eAi3VH0ersUpmlp1UuYN612//h8w==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-13.2.1.tgz",
+      "integrity": "sha512-HkndaAJPR1fi2xrzvP3q4g48WUCb26btGTeg1AKG9FGx9P2dgtpaPRmbMitmgVSzzRurrkxf3Meip8nC7BwDeg==",
       "dependencies": {
-        "@polkadot/rpc-core": "12.1.1",
-        "@polkadot/types": "12.1.1",
-        "@polkadot/types-codec": "12.1.1",
-        "@polkadot/util": "^12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/rpc-core": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-12.1.1.tgz",
-      "integrity": "sha512-NB4BZo9RdAZPBfZ11NoujB8+SDkDgvlrSiiv9FPMhfvTJo0Sr5FAq0Wd2aSC4D/6qbt5e89CHOW+0gBEm9d6dw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-13.2.1.tgz",
+      "integrity": "sha512-hy0GksUlb/TfQ38m3ysIWj3qD+rIsyCdxx8Ug5rIx1u0odv86NZ7nTqtH066Ct2riVaPBgBkObFnlpDWTJ6auA==",
       "dependencies": {
-        "@polkadot/rpc-augment": "12.1.1",
-        "@polkadot/rpc-provider": "12.1.1",
-        "@polkadot/types": "12.1.1",
-        "@polkadot/util": "^12.6.2",
+        "@polkadot/rpc-augment": "13.2.1",
+        "@polkadot/rpc-provider": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/util": "^13.1.1",
         "rxjs": "^7.8.1",
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/rpc-provider": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-12.1.1.tgz",
-      "integrity": "sha512-nDr0Qb5sIzTTx6qmgr9ibNcQs/VDoPzZ+49kcltf0A6BdSytGy532Yhf2A158aD41324V9YPAzxVRLxZyJzhkw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-13.2.1.tgz",
+      "integrity": "sha512-bbMVYHTNFUa89aY3UQ1hFYD+dP+v+0vhjsnHYYlv37rSUTqOGqW91rkHd63xYCpLAimFt7KRw8xR+SMSYiuDjw==",
       "dependencies": {
-        "@polkadot/keyring": "^12.6.2",
-        "@polkadot/types": "12.1.1",
-        "@polkadot/types-support": "12.1.1",
-        "@polkadot/util": "^12.6.2",
-        "@polkadot/util-crypto": "^12.6.2",
-        "@polkadot/x-fetch": "^12.6.2",
-        "@polkadot/x-global": "^12.6.2",
-        "@polkadot/x-ws": "^12.6.2",
+        "@polkadot/keyring": "^13.1.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-support": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "@polkadot/util-crypto": "^13.1.1",
+        "@polkadot/x-fetch": "^13.1.1",
+        "@polkadot/x-global": "^13.1.1",
+        "@polkadot/x-ws": "^13.1.1",
         "eventemitter3": "^5.0.1",
         "mock-socket": "^9.3.1",
-        "nock": "^13.5.0",
-        "tslib": "^2.6.2"
+        "nock": "^13.5.4",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@substrate/connect": "0.8.10"
+        "@substrate/connect": "0.8.11"
       }
     },
     "node_modules/@polkadot/types": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-12.1.1.tgz",
-      "integrity": "sha512-+b8v7ORjL20r6VvdWL/fPTHmDXtfAfqkQQxBB6exxOhqrnJfnhAYQjJomKcyj1VMTQiyyR9FBAc7vVvTEFX2ew==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-13.2.1.tgz",
+      "integrity": "sha512-5yQ0mHMNvwgXeHQ1RZOuHaeak3utAdcBqCpHoagnYrAnGHqtO7kg7YLtT4LkFw2nwL85axu8tOQMv6/3kpFy9w==",
       "dependencies": {
-        "@polkadot/keyring": "^12.6.2",
-        "@polkadot/types-augment": "12.1.1",
-        "@polkadot/types-codec": "12.1.1",
-        "@polkadot/types-create": "12.1.1",
-        "@polkadot/util": "^12.6.2",
-        "@polkadot/util-crypto": "^12.6.2",
+        "@polkadot/keyring": "^13.1.1",
+        "@polkadot/types-augment": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/types-create": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "@polkadot/util-crypto": "^13.1.1",
         "rxjs": "^7.8.1",
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/types-augment": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-12.1.1.tgz",
-      "integrity": "sha512-HdzjaXapcmNAdT6TWJOuv124PTKbAf5+5JldQ7oPZFaCEhaOTazZYiZ27nqLaj0l4rG7wWzFMiGqjbHwAvtmlg==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-13.2.1.tgz",
+      "integrity": "sha512-FpV7/2kIJmmswRmwUbp41lixdNX15olueUjHnSweFk0xEn2Ur43oC0Y3eU3Ab7Y5gPJpceMCfwYz+PjCUGedDA==",
       "dependencies": {
-        "@polkadot/types": "12.1.1",
-        "@polkadot/types-codec": "12.1.1",
-        "@polkadot/util": "^12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/types-codec": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-12.1.1.tgz",
-      "integrity": "sha512-Ob3nFptHT4dDvGc/3l4dBXmvsI3wDWS2oCOxACA+hYWufnlTIQ4M4sHI4kSBQvDoEmaFt8P2Be4SmtyT0VSd1w==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-13.2.1.tgz",
+      "integrity": "sha512-tFAzzS8sMYItoD5a91sFMD+rskWyv4WjSmUZaj0Y4OfLtDAiQvgO0KncdGJIB6D+zZ/T7khpgsv/CZbN3YnezA==",
       "dependencies": {
-        "@polkadot/util": "^12.6.2",
-        "@polkadot/x-bigint": "^12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/util": "^13.1.1",
+        "@polkadot/x-bigint": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/types-create": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-12.1.1.tgz",
-      "integrity": "sha512-K/I4vCnmI7IbtQeURiRMONDqesIVcZp16KEduBcbJm/RWDj0D3mr71066Yr8OhrhteLvULJpViy7EK4ynPvmSw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-13.2.1.tgz",
+      "integrity": "sha512-O/WKdsrNuMaZLf+XRCdum2xJYs5OKC6N3EMPF5Uhg10b80Y/hQCbzA/iWd3/aMNDLUA5XWhixwzJdrZWIMVIzg==",
       "dependencies": {
-        "@polkadot/types-codec": "12.1.1",
-        "@polkadot/util": "^12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/types-known": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-12.1.1.tgz",
-      "integrity": "sha512-4YxY7tB+BVX6k3ubrToYKyh2Jb4QvoLvzwNSGSjyj0RGwiQCu8anFGIzYdaUJ2iQlhLFb6P4AZWykVvhrXGmqg==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-13.2.1.tgz",
+      "integrity": "sha512-uz3c4/IvspLpgN8q15A+QH8KWFauzcrV3RfLFlMP2BkkF5qpOwNeP7c4U8j0CZGQySqBsJRCGWmgBXrXg669KA==",
       "dependencies": {
-        "@polkadot/networks": "^12.6.2",
-        "@polkadot/types": "12.1.1",
-        "@polkadot/types-codec": "12.1.1",
-        "@polkadot/types-create": "12.1.1",
-        "@polkadot/util": "^12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/networks": "^13.1.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/types-create": "13.2.1",
+        "@polkadot/util": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/types-support": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-12.1.1.tgz",
-      "integrity": "sha512-mLXrbj0maKFWqV1+4QRzaNnZyV/rAQW0XSrIzfIZn//zSRSIUaXaVAZ62uzgdmzXXFH2qD3hpNlmvmjcEMm2Qg==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-13.2.1.tgz",
+      "integrity": "sha512-jSbbUTXU+yZJQPRAWmxaDoe4NRO6SjpZPzBIbpuiadx1slON8XB80fVYIGBXuM2xRVrNrB6fCjyCTG7Razj6Hg==",
       "dependencies": {
-        "@polkadot/util": "^12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/util": "^13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/util": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.6.2.tgz",
-      "integrity": "sha512-l8TubR7CLEY47240uki0TQzFvtnxFIO7uI/0GoWzpYD/O62EIAMRsuY01N4DuwgKq2ZWD59WhzsLYmA5K6ksdw==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.1.1.tgz",
+      "integrity": "sha512-M4iQ5Um8tFdDmD7a96nPzfrEt+kxyWOqQDPqXyaax4QBnq/WCbq0jo8IO61uz55mdMQnGZvq8jd8uge4V6JzzQ==",
       "dependencies": {
-        "@polkadot/x-bigint": "12.6.2",
-        "@polkadot/x-global": "12.6.2",
-        "@polkadot/x-textdecoder": "12.6.2",
-        "@polkadot/x-textencoder": "12.6.2",
+        "@polkadot/x-bigint": "13.1.1",
+        "@polkadot/x-global": "13.1.1",
+        "@polkadot/x-textdecoder": "13.1.1",
+        "@polkadot/x-textencoder": "13.1.1",
         "@types/bn.js": "^5.1.5",
         "bn.js": "^5.2.1",
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/util-crypto": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.6.2.tgz",
-      "integrity": "sha512-FEWI/dJ7wDMNN1WOzZAjQoIcCP/3vz3wvAp5QQm+lOrzOLj0iDmaIGIcBkz8HVm3ErfSe/uKP0KS4jgV/ib+Mg==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-13.1.1.tgz",
+      "integrity": "sha512-FG68rrLPdfLcscEyH10vnGkakM4O2lqr71S3GDhgc9WXaS8y9jisLgMPg8jbMHiQBJ3iKYkmtPKiLBowRslj2w==",
       "dependencies": {
         "@noble/curves": "^1.3.0",
         "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "12.6.2",
-        "@polkadot/util": "12.6.2",
+        "@polkadot/networks": "13.1.1",
+        "@polkadot/util": "13.1.1",
         "@polkadot/wasm-crypto": "^7.3.2",
         "@polkadot/wasm-util": "^7.3.2",
-        "@polkadot/x-bigint": "12.6.2",
-        "@polkadot/x-randomvalues": "12.6.2",
-        "@scure/base": "^1.1.5",
-        "tslib": "^2.6.2"
+        "@polkadot/x-bigint": "13.1.1",
+        "@polkadot/x-randomvalues": "13.1.1",
+        "@scure/base": "^1.1.7",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "12.6.2"
+        "@polkadot/util": "13.1.1"
       }
     },
     "node_modules/@polkadot/wasm-bridge": {
@@ -486,139 +493,139 @@
       }
     },
     "node_modules/@polkadot/x-bigint": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.6.2.tgz",
-      "integrity": "sha512-HSIk60uFPX4GOFZSnIF7VYJz7WZA7tpFJsne7SzxOooRwMTWEtw3fUpFy5cYYOeLh17/kHH1Y7SVcuxzVLc74Q==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.1.1.tgz",
+      "integrity": "sha512-Cq4Y6fd9UWtRBZz8RX2tWEBL1IFwUtY6cL8p6HC9yhZtUR6OPjKZe6RIZQa9gSOoIuqZWd6PmtvSNGVH32yfkQ==",
       "dependencies": {
-        "@polkadot/x-global": "12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/x-global": "13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/x-fetch": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.6.2.tgz",
-      "integrity": "sha512-8wM/Z9JJPWN1pzSpU7XxTI1ldj/AfC8hKioBlUahZ8gUiJaOF7K9XEFCrCDLis/A1BoOu7Ne6WMx/vsJJIbDWw==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-13.1.1.tgz",
+      "integrity": "sha512-qA6mIUUebJbS+oWzq/EagZflmaoa9b25WvsxSFn7mCvzKngXzr+GYCY4XiDwKY/S+/pr/kvSCKZ1ia8BDqPBYQ==",
       "dependencies": {
-        "@polkadot/x-global": "12.6.2",
+        "@polkadot/x-global": "13.1.1",
         "node-fetch": "^3.3.2",
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/x-global": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.6.2.tgz",
-      "integrity": "sha512-a8d6m+PW98jmsYDtAWp88qS4dl8DyqUBsd0S+WgyfSMtpEXu6v9nXDgPZgwF5xdDvXhm+P0ZfVkVTnIGrScb5g==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.1.1.tgz",
+      "integrity": "sha512-DViIMmmEs29Qlsp058VTg2Mn7e3/CpGazNnKJrsBa0o1Ptxl13/4Z0fjqCpNi2GB+kaOsnREzxUORrHcU+PqcQ==",
       "dependencies": {
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/x-randomvalues": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.6.2.tgz",
-      "integrity": "sha512-Vr8uG7rH2IcNJwtyf5ebdODMcr0XjoCpUbI91Zv6AlKVYOGKZlKLYJHIwpTaKKB+7KPWyQrk4Mlym/rS7v9feg==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-13.1.1.tgz",
+      "integrity": "sha512-cXj4omwbgzQQSiBtV1ZBw+XhJUU3iz/DS6ghUnGllSZEK+fGqiyaNgeFQzDY0tKjm6kYaDpvtOHR3mHsbzDuTg==",
       "dependencies": {
-        "@polkadot/x-global": "12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/x-global": "13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "12.6.2",
+        "@polkadot/util": "13.1.1",
         "@polkadot/wasm-util": "*"
       }
     },
     "node_modules/@polkadot/x-textdecoder": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.6.2.tgz",
-      "integrity": "sha512-M1Bir7tYvNappfpFWXOJcnxUhBUFWkUFIdJSyH0zs5LmFtFdbKAeiDXxSp2Swp5ddOZdZgPac294/o2TnQKN1w==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-13.1.1.tgz",
+      "integrity": "sha512-LpZ9KYc6HdBH+i86bCmun4g4GWMiWN/1Pzs0hNdanlQMfqp3UGzl1Dqp0nozMvjWAlvyG7ip235VgNMd8HEbqg==",
       "dependencies": {
-        "@polkadot/x-global": "12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/x-global": "13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/x-textencoder": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.6.2.tgz",
-      "integrity": "sha512-4N+3UVCpI489tUJ6cv3uf0PjOHvgGp9Dl+SZRLgFGt9mvxnvpW/7+XBADRMtlG4xi5gaRK7bgl5bmY6OMDsNdw==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-13.1.1.tgz",
+      "integrity": "sha512-w1mT15B9ptN5CJNgN/A0CmBqD5y9OePjBdU6gmAd8KRhwXCF0MTBKcEZk1dHhXiXtX+28ULJWLrfefC5gxy69Q==",
       "dependencies": {
-        "@polkadot/x-global": "12.6.2",
-        "tslib": "^2.6.2"
+        "@polkadot/x-global": "13.1.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@polkadot/x-ws": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.6.2.tgz",
-      "integrity": "sha512-cGZWo7K5eRRQCRl2LrcyCYsrc3lRbTlixZh3AzgU8uX4wASVGRlNWi/Hf4TtHNe1ExCDmxabJzdIsABIfrr7xw==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-13.1.1.tgz",
+      "integrity": "sha512-E/xFmJTiFzu+IK5M3/8W/9fnvNJFelcnunPv/IgO6UST94SDaTsN/Gbeb6SqPb6CsrTHRl3WD+AZ3ErGGwQfEA==",
       "dependencies": {
-        "@polkadot/x-global": "12.6.2",
-        "tslib": "^2.6.2",
-        "ws": "^8.15.1"
+        "@polkadot/x-global": "13.1.1",
+        "tslib": "^2.7.0",
+        "ws": "^8.16.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.7.tgz",
-      "integrity": "sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@substrate/connect": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.8.10.tgz",
-      "integrity": "sha512-DIyQ13DDlXqVFnLV+S6/JDgiGowVRRrh18kahieJxhgvzcWicw5eLc6jpfQ0moVVLBYkO7rctB5Wreldwpva8w==",
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.8.11.tgz",
+      "integrity": "sha512-ofLs1PAO9AtDdPbdyTYj217Pe+lBfTLltdHDs3ds8no0BseoLeAGxpz1mHfi7zB4IxI3YyAiLjH6U8cw4pj4Nw==",
       "deprecated": "versions below 1.x are no longer maintained",
       "optional": true,
       "dependencies": {
         "@substrate/connect-extension-protocol": "^2.0.0",
-        "@substrate/connect-known-chains": "^1.1.4",
-        "@substrate/light-client-extension-helpers": "^0.0.6",
-        "smoldot": "2.0.22"
+        "@substrate/connect-known-chains": "^1.1.5",
+        "@substrate/light-client-extension-helpers": "^1.0.0",
+        "smoldot": "2.0.26"
       }
     },
     "node_modules/@substrate/connect-extension-protocol": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-2.0.0.tgz",
-      "integrity": "sha512-nKu8pDrE3LNCEgJjZe1iGXzaD6OSIDD4Xzz/yo4KO9mQ6LBvf49BVrt4qxBFGL6++NneLiWUZGoh+VSd4PyVIg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-2.1.0.tgz",
+      "integrity": "sha512-Wz5Cbn6S6P4vWfHyrsnPW7g15IAViMaXCk+jYkq4nNEMmzPtTKIEbtxrdDMBKrouOFtYKKp0znx5mh9KTCNqlA==",
       "optional": true
     },
     "node_modules/@substrate/connect-known-chains": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@substrate/connect-known-chains/-/connect-known-chains-1.1.8.tgz",
-      "integrity": "sha512-W0Cpnk//LoMTu5BGDCRRg5NHFR2aZ9OJtLGSgRyq1RP39dQGpoVZIgNC6z+SWRzlmOz3gIgkUCwGvOKVt2BabA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-known-chains/-/connect-known-chains-1.4.1.tgz",
+      "integrity": "sha512-WlFKGEE3naIa7iTyy7hJ0RV0dyGpP7Zic1Z8sXr4bJmSEzZoHcfLRbM1D3T+zFAaitffVCu6k55Vj+CFzMPw1Q==",
       "optional": true
     },
     "node_modules/@substrate/light-client-extension-helpers": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@substrate/light-client-extension-helpers/-/light-client-extension-helpers-0.0.6.tgz",
-      "integrity": "sha512-girltEuxQ1BvkJWmc8JJlk4ZxnlGXc/wkLcNguhY+UoDEMBK0LsdtfzQKIfrIehi4QdeSBlFEFBoI4RqPmsZzA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@substrate/light-client-extension-helpers/-/light-client-extension-helpers-1.0.0.tgz",
+      "integrity": "sha512-TdKlni1mBBZptOaeVrKnusMg/UBpWUORNDv5fdCaJklP4RJiFOzBCrzC+CyVI5kQzsXBisZ+2pXm+rIjS38kHg==",
       "optional": true,
       "dependencies": {
-        "@polkadot-api/json-rpc-provider": "0.0.1",
-        "@polkadot-api/json-rpc-provider-proxy": "0.0.1",
-        "@polkadot-api/observable-client": "0.1.0",
-        "@polkadot-api/substrate-client": "0.0.1",
+        "@polkadot-api/json-rpc-provider": "^0.0.1",
+        "@polkadot-api/json-rpc-provider-proxy": "^0.1.0",
+        "@polkadot-api/observable-client": "^0.3.0",
+        "@polkadot-api/substrate-client": "^0.1.2",
         "@substrate/connect-extension-protocol": "^2.0.0",
-        "@substrate/connect-known-chains": "^1.1.4",
+        "@substrate/connect-known-chains": "^1.1.5",
         "rxjs": "^7.8.1"
       },
       "peerDependencies": {
@@ -626,24 +633,24 @@
       }
     },
     "node_modules/@substrate/ss58-registry": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.49.0.tgz",
-      "integrity": "sha512-leW6Ix4LD7XgvxT7+aobPWSw+WvPcN2Rxof1rmd0mNC5t2n99k1N7UNEvz7YEFSOUeHWmKIY7F5q8KeIqYoHfA=="
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.50.0.tgz",
+      "integrity": "sha512-mkmlMlcC+MSd9rA+PN8ljGAm5fVZskvVwkXIsbx4NFwaT8kt38r7e9cyDWscG3z2Zn40POviZvEMrJSk+r2SgQ=="
     },
     "node_modules/@types/bn.js": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.5.tgz",
-      "integrity": "sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.6.tgz",
+      "integrity": "sha512-Xh8vSwUeMKeYYrj3cX4lGQgFSF/N03r+tv4AiLl1SucqV+uTQpxRcnM8AkXKHwYP9ZPXOYXRr2KPXpVlIvqh9w==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
-      "version": "20.14.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
-      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+      "version": "22.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.6.1.tgz",
+      "integrity": "sha512-V48tCfcKb/e6cVUigLAaJDAILdMP0fUW6BidkPK4GpGjXcfbnoHasCZDwz3N3yVt5we2RHm4XTQCpv0KJz9zqw==",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/bn.js": {
@@ -660,11 +667,11 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -727,14 +734,14 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nock": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
-      "integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
+      "version": "13.5.5",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.5.tgz",
+      "integrity": "sha512-XKYnqUrCwXC8DGG1xX4YH5yNIrlh9c065uaMZZHUoeUUINTOyt+x/G+ezYk0Ft6ExSREVIs+qBJDK503viTfFA==",
       "dependencies": {
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
@@ -802,23 +809,23 @@
       "optional": true
     },
     "node_modules/smoldot": {
-      "version": "2.0.22",
-      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.22.tgz",
-      "integrity": "sha512-B50vRgTY6v3baYH6uCgL15tfaag5tcS2o/P5q1OiXcKGv1axZDfz2dzzMuIkVpyMR2ug11F6EAtQlmYBQd292g==",
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.26.tgz",
+      "integrity": "sha512-F+qYmH4z2s2FK+CxGj8moYcd1ekSIKH8ywkdqlOz88Dat35iB1DIYL11aILN46YSGMzQW/lbJNS307zBSDN5Ig==",
       "optional": true,
       "dependencies": {
         "ws": "^8.8.1"
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
@@ -829,9 +836,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/tools/state-copy/package.json
+++ b/tools/state-copy/package.json
@@ -8,7 +8,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@polkadot/api": "^12.1.1",
-    "@polkadot/keyring": "^12.6.2"
+    "@polkadot/api": "^13.2.1",
+    "@polkadot/keyring": "^13.1.1"
   }
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to fix a typo in API Augment

Closes #2054

# Discussion

- Just a typo in API Augment in the Runtime API interface
- Updated js dependencies as well

# Testing

Not simple, but if you want to you have to:
- Pull branch
- Build api-augment: `make js`
- Pull the polkadotjs/apps
- Manually install frequency api-augment build and run
- Test that you can now call get_by_schema_id from the Runtime API interface
