### PR TITLE
Schema Migration fix for newer mainnet schema data

### DIFF
--- a/pallets/schemas/src/migration/v4.rs
+++ b/pallets/schemas/src/migration/v4.rs
@@ -14,7 +14,7 @@ use sp_runtime::TryRuntimeError;
 use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
 /// get known schema names for mainnet
-pub fn get_known_schemas<T: Config>() -> BTreeMap<SchemaId, Vec<u8>> {
+pub fn get_known_schemas<T: Config>() -> BTreeMap<SchemaId, (Vec<u8>, bool)> {
 	let genesis_block: BlockNumberFor<T> = 0u32.into();
 	let genesis = <frame_system::Pallet<T>>::block_hash(genesis_block);
 
@@ -22,13 +22,15 @@ pub fn get_known_schemas<T: Config>() -> BTreeMap<SchemaId, Vec<u8>> {
 		get_chain_type_by_genesis_hash(&genesis.encode()[..])
 	{
 		// only return what needs to change which for this case is only on mainnet
+		// (schema_id, name, clear prior versions)
 		BTreeMap::from([
-			(5, b"dsnp.update".to_vec()),
-			(6, b"dsnp.profile".to_vec()),
-			(7, b"dsnp.public-key-key-agreement".to_vec()),
-			(8, b"dsnp.public-follows".to_vec()),
-			(9, b"dsnp.private-follows".to_vec()),
-			(10, b"dsnp.private-connections".to_vec()),
+			(5, (b"dsnp.update".to_vec(), true)),
+			(19, (b"dsnp.update".to_vec(), false)),
+			(6, (b"dsnp.profile".to_vec(), true)),
+			(7, (b"dsnp.public-key-key-agreement".to_vec(), false)),
+			(8, (b"dsnp.public-follows".to_vec(), false)),
+			(9, (b"dsnp.private-follows".to_vec(), false)),
+			(10, (b"dsnp.private-connections".to_vec(), false)),
 		])
 	} else {
 		BTreeMap::new()
@@ -104,7 +106,7 @@ pub fn migrate_to_v4<T: Config>() -> Weight {
 		let mut writes = 0u64;
 		let mut bytes = 0u64;
 
-		for (schema_id, schema_name) in known_schemas.iter() {
+		for (schema_id, (schema_name, should_clear)) in known_schemas.iter() {
 			reads.saturating_inc();
 
 			if let Some(mut schema) = SchemaInfos::<T>::get(&schema_id) {
@@ -122,7 +124,9 @@ pub fn migrate_to_v4<T: Config>() -> Weight {
 										.saturating_add(schema_version_id.encode().len() as u64);
 
 									// clear the old/wrong one in case they exist
-									schema_version_id.ids.clear();
+									if *should_clear {
+										schema_version_id.ids.clear();
+									}
 									let _ = schema_version_id.add::<T>(*schema_id);
 
 									// set schema as having a name

--- a/pallets/schemas/src/migration/v4.rs
+++ b/pallets/schemas/src/migration/v4.rs
@@ -1,9 +1,9 @@
+#[cfg(feature = "try-runtime")]
+use crate::types::SCHEMA_STORAGE_VERSION;
 use crate::{
 	pallet::{SchemaInfos, SchemaNameToIds},
 	Config, Pallet, SchemaId, SchemaName, LOG_TARGET,
 };
-#[cfg(feature = "try-runtime")]
-use crate::{types::SCHEMA_STORAGE_VERSION, SchemaVersionId};
 use common_primitives::utils::{get_chain_type_by_genesis_hash, DetectedChainType};
 use frame_support::{pallet_prelude::*, traits::OnRuntimeUpgrade, weights::Weight};
 use frame_system::pallet_prelude::BlockNumberFor;
@@ -71,7 +71,7 @@ impl<T: Config> OnRuntimeUpgrade for MigrateToV4<T> {
 		assert_eq!(onchain_version, SCHEMA_STORAGE_VERSION);
 		// check to ensure updates took place
 		let known_schemas = get_known_schemas::<T>();
-		for (schema_id, (schema_name, should_clear)) in known_schemas.into_iter() {
+		for (schema_id, (schema_name, _should_clear)) in known_schemas.into_iter() {
 			// safe to use unwrap since only used in try_runtime
 			let bounded = BoundedVec::try_from(schema_name).unwrap();
 			let parsed_name = SchemaName::try_parse::<T>(bounded, true).unwrap();
@@ -81,9 +81,8 @@ impl<T: Config> OnRuntimeUpgrade for MigrateToV4<T> {
 			// Just check that it contains the correct value, not position anymore
 			assert!(
 				current_versions.ids.iter().any(|&id| id == schema_id),
-				"Current versions does not contain schema_id {} for name {:?}",
-				schema_id,
-				parsed_name
+				"Current versions does not contain schema_id {}",
+				schema_id
 			);
 		}
 		log::info!(target: LOG_TARGET, "Finished post_upgrade");


### PR DESCRIPTION
# Goal
The goal of this PR is to update the schemas migration with respect to the newer data on chain.

Part of #2006 

# Discussion

- Only reset the name list as needed
- Add in schema 19 so that it is re-added at the top of the list


# Result of `try-runtime`

[2024-09-26T20:42:48Z INFO  runtime::schemas] Running pre_upgrade...
[2024-09-26T20:42:48Z INFO  runtime::schemas] Running storage migration...
[2024-09-26T20:42:48Z INFO  runtime::schemas] Storage migrated to version 4  read=15, write=15, bytes=11138
[2024-09-26T20:42:48Z INFO  runtime::schemas] Migration Calculated weights=Weight { ref_time: 1824840000, proof_size: 11138 }
[2024-09-26T20:42:48Z INFO  runtime::schemas] Running post_upgrade...
[2024-09-26T20:42:48Z INFO  runtime::schemas] Finished post_upgrade