### PR TITLE
Disable `report_invalid` in the vendor'd transaction pool

### DIFF
--- a/vendor/transaction-pool/src/graph/ready.rs
+++ b/vendor/transaction-pool/src/graph/ready.rs
@@ -508,7 +508,7 @@ impl<Hash: hash::Hash + Member, Ex> BestIterator<Hash, Ex> {
 impl<Hash: hash::Hash + Member, Ex> sc_transaction_pool_api::ReadyTransactions
 	for BestIterator<Hash, Ex>
 {
-	fn report_invalid(&mut self, tx: &Self::Item) {
+	fn report_invalid(&mut self, _tx: &Self::Item) {
 		// HACK: This is a temparary hack for https://github.com/frequency-chain/frequency/issues/1927
 		// See the issue for more details
 		// Why: Valid transactions were being marked as invalid to do blocks
@@ -523,7 +523,7 @@ impl<Hash: hash::Hash + Member, Ex> BestIterator<Hash, Ex> {
 	/// As a consequence, all values that depend on the invalid one will be skipped.
 	/// When given transaction is not in the pool it has no effect.
 	/// When invoked on a fully drained iterator it has no effect either.
-	pub fn report_invalid(&mut self, tx: &Arc<Transaction<Hash, Ex>>) {
+	pub fn _report_invalid(&mut self, tx: &Arc<Transaction<Hash, Ex>>) {
 		if let Some(to_report) = self.all.get(&tx.hash) {
 			debug!(
 				target: LOG_TARGET,

--- a/vendor/transaction-pool/src/graph/ready.rs
+++ b/vendor/transaction-pool/src/graph/ready.rs
@@ -509,7 +509,11 @@ impl<Hash: hash::Hash + Member, Ex> sc_transaction_pool_api::ReadyTransactions
 	for BestIterator<Hash, Ex>
 {
 	fn report_invalid(&mut self, tx: &Self::Item) {
-		BestIterator::report_invalid(self, tx)
+		// HACK: This is a temparary hack for https://github.com/frequency-chain/frequency/issues/1927
+		// See the issue for more details
+		// Why: Valid transactions were being marked as invalid to do blocks
+		// Cost: Invalid transactions will not be removed from the pool until the node restarts
+		// BestIterator::report_invalid(self, tx)
 	}
 }
 

--- a/vendor/transaction-pool/src/graph/ready.rs
+++ b/vendor/transaction-pool/src/graph/ready.rs
@@ -508,12 +508,8 @@ impl<Hash: hash::Hash + Member, Ex> BestIterator<Hash, Ex> {
 impl<Hash: hash::Hash + Member, Ex> sc_transaction_pool_api::ReadyTransactions
 	for BestIterator<Hash, Ex>
 {
-	fn report_invalid(&mut self, _tx: &Self::Item) {
-		// HACK: This is a temparary hack for https://github.com/frequency-chain/frequency/issues/1927
-		// See the issue for more details
-		// Why: Valid transactions were being marked as invalid to do blocks
-		// Cost: Invalid transactions will not be removed from the pool until the node restarts
-		// BestIterator::report_invalid(self, tx)
+	fn report_invalid(&mut self, tx: &Self::Item) {
+		BestIterator::report_invalid(self, tx)
 	}
 }
 
@@ -523,16 +519,20 @@ impl<Hash: hash::Hash + Member, Ex> BestIterator<Hash, Ex> {
 	/// As a consequence, all values that depend on the invalid one will be skipped.
 	/// When given transaction is not in the pool it has no effect.
 	/// When invoked on a fully drained iterator it has no effect either.
-	pub fn _report_invalid(&mut self, tx: &Arc<Transaction<Hash, Ex>>) {
+	pub fn report_invalid(&mut self, tx: &Arc<Transaction<Hash, Ex>>) {
 		if let Some(to_report) = self.all.get(&tx.hash) {
 			debug!(
 				target: LOG_TARGET,
 				"[{:?}] Reported as invalid. Will skip sub-chains while iterating.",
 				to_report.transaction.transaction.hash
 			);
-			for hash in &to_report.unlocks {
-				self.invalid.insert(hash.clone());
-			}
+			// HACK: This is a temparary hack for https://github.com/frequency-chain/frequency/issues/1927
+			// See the issue for more details
+			// Why: Valid transactions were being marked as invalid to do blocks
+			// Cost: Invalid transactions will not be removed from the pool until the node restarts
+			// for hash in &to_report.unlocks {
+			// 	self.invalid.insert(hash.clone());
+			// }
 		}
 	}
 }

--- a/vendor/transaction-pool/src/graph/validated_pool.rs
+++ b/vendor/transaction-pool/src/graph/validated_pool.rs
@@ -598,21 +598,28 @@ impl<B: ChainApi> ValidatedPool<B> {
 			return vec![]
 		}
 
-		log::debug!(target: LOG_TARGET, "Removing invalid transactions: {:?}", hashes);
+		// HACK: This is a temparary hack for https://github.com/frequency-chain/frequency/issues/1927
+		// See the issue for more details
+		// Why: Valid transactions were being marked as invalid to do blocks
+		// Cost: Invalid transactions will not be removed from the pool until the node restarts
+		log::debug!(target: LOG_TARGET, "HACK LOG: NOT Removing invalid transactions: {:?}", hashes);
+		return vec![];
 
-		// temporarily ban invalid transactions
-		self.rotator.ban(&Instant::now(), hashes.iter().cloned());
+		// log::debug!(target: LOG_TARGET, "Removing invalid transactions: {:?}", hashes);
 
-		let invalid = self.pool.write().remove_subtree(hashes);
+		// // temporarily ban invalid transactions
+		// self.rotator.ban(&Instant::now(), hashes.iter().cloned());
 
-		log::debug!(target: LOG_TARGET, "Removed invalid transactions: {:?}", invalid);
+		// let invalid = self.pool.write().remove_subtree(hashes);
 
-		let mut listener = self.listener.write();
-		for tx in &invalid {
-			listener.invalid(&tx.hash);
-		}
+		// log::debug!(target: LOG_TARGET, "Removed invalid transactions: {:?}", invalid);
 
-		invalid
+		// let mut listener = self.listener.write();
+		// for tx in &invalid {
+		// 	listener.invalid(&tx.hash);
+		// }
+
+		// invalid
 	}
 
 	/// Get an iterator for ready transactions ordered by priority


### PR DESCRIPTION
# Goal
The goal of this PR is to separate into a separate PR the only change happening to the vender'd transaction pool