### PR TITLE
Fix E2E tests Paseo Schema Defaults

### DIFF
--- a/e2e/scaffolding/env.ts
+++ b/e2e/scaffolding/env.ts
@@ -46,7 +46,7 @@ export function getBroadcastSchema() {
 export function getDummySchema() {
   switch (process.env.CHAIN_ENVIRONMENT) {
     case CHAIN_ENVIRONMENT.PASEO_TESTNET:
-      return 12;
+      return 16_074;
   }
   return null;
 }
@@ -54,7 +54,7 @@ export function getDummySchema() {
 export function getAvroChatMessagePaginatedSchema() {
   switch (process.env.CHAIN_ENVIRONMENT) {
     case CHAIN_ENVIRONMENT.PASEO_TESTNET:
-      return 14;
+      return 16_075;
   }
   return null;
 }
@@ -62,7 +62,7 @@ export function getAvroChatMessagePaginatedSchema() {
 export function getAvroChatMessageItemizedSchema() {
   switch (process.env.CHAIN_ENVIRONMENT) {
     case CHAIN_ENVIRONMENT.PASEO_TESTNET:
-      return 13;
+      return 16_073;
   }
   return null;
 }

--- a/e2e/stateful-pallet-storage/handleItemized.test.ts
+++ b/e2e/stateful-pallet-storage/handleItemized.test.ts
@@ -18,7 +18,7 @@ import { getFundingSource } from '../scaffolding/funding';
 
 const fundingSource = getFundingSource('stateful-storage-handle-itemized');
 
-describe('📗 Stateful Pallet Storage', function () {
+describe('📗 Stateful Pallet Storage Itemized', function () {
   let schemaId_deletable: SchemaId;
   let schemaId_unsupported: SchemaId;
   let delegatorKeys: KeyringPair;

--- a/e2e/stateful-pallet-storage/handlePaginated.test.ts
+++ b/e2e/stateful-pallet-storage/handlePaginated.test.ts
@@ -19,7 +19,7 @@ import { getFundingSource } from '../scaffolding/funding';
 const badSchemaId = 65_534;
 const fundingSource = getFundingSource('stateful-storage-handle-paginated');
 
-describe('📗 Stateful Pallet Storage', function () {
+describe('📗 Stateful Pallet Storage Paginated', function () {
   let schemaId: SchemaId;
   let schemaId_unsupported: SchemaId;
   let delegatorKeys: KeyringPair;


### PR DESCRIPTION
# Goal

Because of pulling in the schemas from mainnet to testnet, the old test schemas were overwritten.

The goal of this PR is to update it with the new schemas.

Part of #2154 

# Discussion

- A simple naming update as well to separate out these two tests in the run

## Testing

Check that the schemas in the list match those on testnet