### PR TITLE
Fix/e2e test improvements

### DIFF
--- a/e2e/.relay-chain.mocharc.json
+++ b/e2e/.relay-chain.mocharc.json
@@ -5,5 +5,5 @@
   "require": ["scaffolding/globalHooks.ts", "scaffolding/rootHooks.ts", "scaffolding/extrinsicHelpers.ts"],
   "import": "tsx/esm",
   "spec": ["./{,!(node_modules|load-tests)/**}/*.test.ts"],
-  "timeout": 600000
+  "timeout": 180000
 }

--- a/e2e/capacity/capacityFail.test.ts
+++ b/e2e/capacity/capacityFail.test.ts
@@ -1,0 +1,226 @@
+import '@frequency-chain/api-augment';
+import { KeyringPair } from '@polkadot/keyring/types';
+import { Bytes, u64, u16 } from '@polkadot/types';
+import assert from 'assert';
+import { AddKeyData, ExtrinsicHelper } from '../scaffolding/extrinsicHelpers';
+import {
+  createKeys,
+  createAndFundKeypair,
+  createMsaAndProvider,
+  generateDelegationPayload,
+  getBlockNumber,
+  signPayloadSr25519,
+  stakeToProvider,
+  generateAddKeyPayload,
+  CENTS,
+  DOLLARS,
+  getOrCreateGraphChangeSchema,
+  getTestHandle,
+  assertAddNewKey,
+} from '../scaffolding/helpers';
+import { getFundingSource } from '../scaffolding/funding';
+
+const FUNDS_AMOUNT: bigint = 50n * DOLLARS;
+const fundingSource = getFundingSource('capacity-transactions-fail');
+
+describe('Capacity Transaction Failures', function () {
+  describe('pay_with_capacity', function () {
+    describe('when caller does not have a Capacity account', function () {
+      let delegatorKeys: KeyringPair;
+      let delegatorProviderId: u64;
+      let schemaId: u16;
+
+      beforeEach(async function () {
+        // Create and fund a keypair with EXISTENTIAL_DEPOSIT
+        // Use this keypair for delegator operations
+        delegatorKeys = createKeys('OtherProviderKeys');
+        delegatorProviderId = await createMsaAndProvider(fundingSource, delegatorKeys, 'Delegator', FUNDS_AMOUNT);
+        schemaId = new u16(ExtrinsicHelper.api.registry, 0);
+      });
+
+      describe('but has an MSA account that has not been registered as a Provider', function () {
+        it('fails to pay for a transaction', async function () {
+          // Create a keypair with msaId, but no provider
+          const noProviderKeys = await createAndFundKeypair(fundingSource, FUNDS_AMOUNT, 'NoProviderKeys');
+
+          const createMsaOp = ExtrinsicHelper.createMsa(noProviderKeys);
+
+          const { target: msaCreatedEvent } = await createMsaOp.fundAndSend(fundingSource);
+          assert.notEqual(msaCreatedEvent, undefined, 'should have returned MsaCreated event');
+
+          // When a user is not a registered provider and attempts to pay with Capacity,
+          // it should error with InvalidTransaction::Payment, which is a 1010 error, Inability to pay some fees.
+          const payload = await generateDelegationPayload({
+            authorizedMsaId: delegatorProviderId,
+            schemaIds: [schemaId],
+          });
+          const addProviderData = ExtrinsicHelper.api.registry.createType('PalletMsaAddProvider', payload);
+          const grantDelegationOp = ExtrinsicHelper.grantDelegation(
+            delegatorKeys,
+            noProviderKeys,
+            signPayloadSr25519(delegatorKeys, addProviderData),
+            payload
+          );
+
+          await assert.rejects(grantDelegationOp.payWithCapacity('current'), {
+            name: 'RpcError',
+            message: '1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low',
+          });
+        });
+      });
+
+      describe('and does not have an MSA account associated to signing keys', function () {
+        it('fails to pay for a transaction', async function () {
+          const emptyKeys = await createAndFundKeypair(fundingSource, 50_000_000n);
+
+          const payload = await generateDelegationPayload({
+            authorizedMsaId: delegatorProviderId,
+            schemaIds: [schemaId],
+          });
+          const addProviderData = ExtrinsicHelper.api.registry.createType('PalletMsaAddProvider', payload);
+          const grantDelegationOp = ExtrinsicHelper.grantDelegation(
+            delegatorKeys,
+            emptyKeys,
+            signPayloadSr25519(delegatorKeys, addProviderData),
+            payload
+          );
+
+          await assert.rejects(grantDelegationOp.payWithCapacity('current'), {
+            name: 'RpcError',
+            message: '1010: Invalid Transaction: Custom error: 1',
+          });
+        });
+      });
+    });
+
+    describe('when caller has a Capacity account', function () {
+      let schemaId: u16;
+      const amountStaked = 3n * DOLLARS;
+
+      before(async function () {
+        // Create schemas for testing with Grant Delegation to test pay_with_capacity
+        schemaId = await getOrCreateGraphChangeSchema(fundingSource);
+        assert.notEqual(schemaId, undefined, 'setup should populate schemaId');
+      });
+
+      it('fails when a provider makes an eligible extrinsic call using non-funded control key', async function () {
+        const capacityKeys = createKeys('CapacityKeysNSF');
+        const capacityProvider = await createMsaAndProvider(fundingSource, capacityKeys, 'CapProvNSF', FUNDS_AMOUNT);
+        // this will first fund 'capacityKeys' before staking
+        await assert.doesNotReject(stakeToProvider(fundingSource, fundingSource, capacityProvider, amountStaked));
+
+        // As current owner, add a new set of control keys that do not have a balance.
+        const newControlKeypair = createKeys('NewKeyNoBalance');
+        const newPublicKey = newControlKeypair.publicKey;
+        const addKeyPayload: AddKeyData = await generateAddKeyPayload({
+          msaId: capacityProvider,
+          newPublicKey: newPublicKey,
+        });
+        await assertAddNewKey(capacityKeys, addKeyPayload, newControlKeypair);
+
+        // attempt a capacity transaction using the new unfunded key: claimHandle
+        const handle = getTestHandle();
+        const expiration = (await getBlockNumber()) + 10;
+        const handle_vec = new Bytes(ExtrinsicHelper.api.registry, handle);
+        const handlePayload = {
+          baseHandle: handle_vec,
+          expiration: expiration,
+        };
+        const claimHandlePayload = ExtrinsicHelper.api.registry.createType(
+          'CommonPrimitivesHandlesClaimHandlePayload',
+          handlePayload
+        );
+        const claimHandle = ExtrinsicHelper.claimHandle(newControlKeypair, claimHandlePayload);
+        await assert.rejects(claimHandle.payWithCapacity('current'), {
+          name: 'RpcError',
+          message: '1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low',
+        });
+      });
+
+      // When a user attempts to pay for a non-capacity transaction with Capacity,
+      // it should error and drop the transaction from the transaction-pool.
+      it('fails to pay with Capacity for a non-capacity transaction', async function () {
+        const capacityKeys = createKeys('CapacityKeys');
+        const capacityProvider = await createMsaAndProvider(
+          fundingSource,
+          capacityKeys,
+          'CapacityProvider',
+          FUNDS_AMOUNT
+        );
+        const nonCapacityTxn = ExtrinsicHelper.stake(capacityKeys, capacityProvider, 1n * CENTS);
+        await assert.rejects(nonCapacityTxn.payWithCapacity('current'), {
+          name: 'RpcError',
+          message: '1010: Invalid Transaction: Custom error: 0',
+        });
+      });
+
+      // When a user does not have enough capacity to pay for the transaction fee
+      // and is NOT eligible to replenish Capacity, it should error and be dropped
+      // from the transaction pool.
+      it('fails to pay for a transaction with empty capacity', async function () {
+        const noCapacityKeys = createKeys('noCapacityKeys');
+        const noCapacityProvider = await createMsaAndProvider(fundingSource, noCapacityKeys, 'NoCapProvider');
+
+        const delegatorKeys = createKeys('delegatorKeys');
+
+        const payload = await generateDelegationPayload({
+          authorizedMsaId: noCapacityProvider,
+          schemaIds: [schemaId],
+        });
+        const addProviderData = ExtrinsicHelper.api.registry.createType('PalletMsaAddProvider', payload);
+        const grantDelegationOp = ExtrinsicHelper.createSponsoredAccountWithDelegation(
+          delegatorKeys,
+          noCapacityKeys,
+          signPayloadSr25519(noCapacityKeys, addProviderData),
+          payload
+        );
+
+        await assert.rejects(grantDelegationOp.payWithCapacity('current'), {
+          name: 'RpcError',
+          message: '1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low',
+        });
+      });
+
+      // *All keys should have at least an EXISTENTIAL_DEPOSIT = 1M.
+      it('fails to pay for transaction when key does has not met the min deposit', async function () {
+        const capacityKeys = createKeys('CapKeysUnder');
+        const capacityProvider = await createMsaAndProvider(fundingSource, capacityKeys, 'CapProvUnder', FUNDS_AMOUNT);
+        const noTokensKeys = createKeys('noTokensKeys');
+        const delegatorKeys = createKeys('delegatorKeys');
+
+        await assert.doesNotReject(stakeToProvider(fundingSource, fundingSource, capacityProvider, 1n * DOLLARS));
+
+        // Add new key
+        const newKeyPayload: AddKeyData = await generateAddKeyPayload({
+          msaId: new u64(ExtrinsicHelper.api.registry, capacityProvider),
+          newPublicKey: noTokensKeys.publicKey,
+        });
+        const addKeyData = ExtrinsicHelper.api.registry.createType('PalletMsaAddKeyData', newKeyPayload);
+
+        const ownerSig = signPayloadSr25519(capacityKeys, addKeyData);
+        const newSig = signPayloadSr25519(noTokensKeys, addKeyData);
+        const addPublicKeyOp = ExtrinsicHelper.addPublicKeyToMsa(capacityKeys, ownerSig, newSig, newKeyPayload);
+
+        const { target: publicKeyEvent } = await addPublicKeyOp.fundAndSend(fundingSource);
+        assert.notEqual(publicKeyEvent, undefined, 'should have added public key');
+
+        const payload = await generateDelegationPayload({
+          authorizedMsaId: capacityProvider,
+          schemaIds: [schemaId],
+        });
+        const addProviderData = ExtrinsicHelper.api.registry.createType('PalletMsaAddProvider', payload);
+        const grantDelegationOp = ExtrinsicHelper.createSponsoredAccountWithDelegation(
+          delegatorKeys,
+          noTokensKeys,
+          signPayloadSr25519(delegatorKeys, addProviderData),
+          payload
+        );
+
+        await assert.rejects(grantDelegationOp.payWithCapacity('current'), {
+          name: 'RpcError',
+          message: '1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low',
+        });
+      });
+    });
+  });
+});

--- a/e2e/capacity/transactions.test.ts
+++ b/e2e/capacity/transactions.test.ts
@@ -1,10 +1,8 @@
 import '@frequency-chain/api-augment';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { Bytes, u64, u16 } from '@polkadot/types';
-import { u8aToHex } from '@polkadot/util/u8a/toHex';
-import { u8aWrapBytes } from '@polkadot/util';
 import assert from 'assert';
-import { AddKeyData, AddProviderPayload, EventMap, ExtrinsicHelper } from '../scaffolding/extrinsicHelpers';
+import { AddKeyData, EventMap, ExtrinsicHelper } from '../scaffolding/extrinsicHelpers';
 import { base64 } from 'multiformats/bases/base64';
 import { SchemaId } from '@frequency-chain/api-augment/interfaces';
 import {
@@ -37,7 +35,6 @@ import {
   getCapacity,
   getTestHandle,
   assertHasMessage,
-  assertAddNewKey,
 } from '../scaffolding/helpers';
 import { ipfsCid } from '../messages/ipfs';
 import { getFundingSource } from '../scaffolding/funding';
@@ -66,40 +63,6 @@ describe('Capacity Transactions', function () {
         }
         return 0n;
       }
-
-      it('fails when a provider makes an eligible extrinsic call using non-funded control key', async function () {
-        const capacityKeys = createKeys('CapacityKeysNSF');
-        const capacityProvider = await createMsaAndProvider(fundingSource, capacityKeys, 'CapProvNSF', FUNDS_AMOUNT);
-        // this will first fund 'capacityKeys' before staking
-        await assert.doesNotReject(stakeToProvider(fundingSource, fundingSource, capacityProvider, amountStaked));
-
-        // As current owner, add a new set of control keys that do not have a balance.
-        const newControlKeypair = createKeys('NewKeyNoBalance');
-        const newPublicKey = newControlKeypair.publicKey;
-        const addKeyPayload: AddKeyData = await generateAddKeyPayload({
-          msaId: capacityProvider,
-          newPublicKey: newPublicKey,
-        });
-        await assertAddNewKey(capacityKeys, addKeyPayload, newControlKeypair);
-
-        // attempt a capacity transaction using the new unfunded key: claimHandle
-        const handle = getTestHandle();
-        const expiration = (await getBlockNumber()) + 10;
-        const handle_vec = new Bytes(ExtrinsicHelper.api.registry, handle);
-        const handlePayload = {
-          baseHandle: handle_vec,
-          expiration: expiration,
-        };
-        const claimHandlePayload = ExtrinsicHelper.api.registry.createType(
-          'CommonPrimitivesHandlesClaimHandlePayload',
-          handlePayload
-        );
-        const claimHandle = ExtrinsicHelper.claimHandle(newControlKeypair, claimHandlePayload);
-        await assert.rejects(claimHandle.payWithCapacity('current'), {
-          name: 'RpcError',
-          message: '1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low',
-        });
-      });
 
       describe('when capacity eligible transaction is from the msa pallet', function () {
         let capacityKeys: KeyringPair;
@@ -604,159 +567,6 @@ describe('Capacity Transactions', function () {
           assertEvent(eventMap, 'system.ExtrinsicSuccess');
           assertEvent(eventMap, 'capacity.CapacityWithdrawn');
           assertEvent(eventMap, 'handles.HandleClaimed');
-        });
-      });
-
-      // When a user attempts to pay for a non-capacity transaction with Capacity,
-      // it should error and drop the transaction from the transaction-pool.
-      it('fails to pay with Capacity for a non-capacity transaction', async function () {
-        const capacityKeys = createKeys('CapacityKeys');
-        const capacityProvider = await createMsaAndProvider(
-          fundingSource,
-          capacityKeys,
-          'CapacityProvider',
-          FUNDS_AMOUNT
-        );
-        const nonCapacityTxn = ExtrinsicHelper.stake(capacityKeys, capacityProvider, 1n * CENTS);
-        await assert.rejects(nonCapacityTxn.payWithCapacity('current'), {
-          name: 'RpcError',
-          message: '1010: Invalid Transaction: Custom error: 0',
-        });
-      });
-
-      // When a user does not have enough capacity to pay for the transaction fee
-      // and is NOT eligible to replenish Capacity, it should error and be dropped
-      // from the transaction pool.
-      it('fails to pay for a transaction with empty capacity', async function () {
-        const noCapacityKeys = createKeys('noCapacityKeys');
-        const noCapacityProvider = await createMsaAndProvider(fundingSource, noCapacityKeys, 'NoCapProvider');
-
-        const delegatorKeys = createKeys('delegatorKeys');
-
-        const payload = await generateDelegationPayload({
-          authorizedMsaId: noCapacityProvider,
-          schemaIds: [schemaId],
-        });
-        const addProviderData = ExtrinsicHelper.api.registry.createType('PalletMsaAddProvider', payload);
-        const grantDelegationOp = ExtrinsicHelper.createSponsoredAccountWithDelegation(
-          delegatorKeys,
-          noCapacityKeys,
-          signPayloadSr25519(noCapacityKeys, addProviderData),
-          payload
-        );
-
-        await assert.rejects(grantDelegationOp.payWithCapacity('current'), {
-          name: 'RpcError',
-          message: '1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low',
-        });
-      });
-
-      // *All keys should have at least an EXISTENTIAL_DEPOSIT = 1M.
-      it('fails to pay for transaction when key does has not met the min deposit', async function () {
-        const capacityKeys = createKeys('CapKeysUnder');
-        const capacityProvider = await createMsaAndProvider(fundingSource, capacityKeys, 'CapProvUnder', FUNDS_AMOUNT);
-        const noTokensKeys = createKeys('noTokensKeys');
-        const delegatorKeys = createKeys('delegatorKeys');
-
-        await assert.doesNotReject(stakeToProvider(fundingSource, fundingSource, capacityProvider, 1n * DOLLARS));
-
-        // Add new key
-        const newKeyPayload: AddKeyData = await generateAddKeyPayload({
-          msaId: new u64(ExtrinsicHelper.api.registry, capacityProvider),
-          newPublicKey: noTokensKeys.publicKey,
-        });
-        const addKeyData = ExtrinsicHelper.api.registry.createType('PalletMsaAddKeyData', newKeyPayload);
-
-        const ownerSig = signPayloadSr25519(capacityKeys, addKeyData);
-        const newSig = signPayloadSr25519(noTokensKeys, addKeyData);
-        const addPublicKeyOp = ExtrinsicHelper.addPublicKeyToMsa(capacityKeys, ownerSig, newSig, newKeyPayload);
-
-        const { target: publicKeyEvent } = await addPublicKeyOp.fundAndSend(fundingSource);
-        assert.notEqual(publicKeyEvent, undefined, 'should have added public key');
-
-        const payload = await generateDelegationPayload({
-          authorizedMsaId: capacityProvider,
-          schemaIds: [schemaId],
-        });
-        const addProviderData = ExtrinsicHelper.api.registry.createType('PalletMsaAddProvider', payload);
-        const grantDelegationOp = ExtrinsicHelper.createSponsoredAccountWithDelegation(
-          delegatorKeys,
-          noTokensKeys,
-          signPayloadSr25519(delegatorKeys, addProviderData),
-          payload
-        );
-
-        await assert.rejects(grantDelegationOp.payWithCapacity('current'), {
-          name: 'RpcError',
-          message: '1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low',
-        });
-      });
-    });
-
-    describe('when caller does not have a Capacity account', function () {
-      let delegatorKeys: KeyringPair;
-      let delegatorProviderId: u64;
-      let schemaId: u16;
-
-      beforeEach(async function () {
-        // Create and fund a keypair with EXISTENTIAL_DEPOSIT
-        // Use this keypair for delegator operations
-        delegatorKeys = createKeys('OtherProviderKeys');
-        delegatorProviderId = await createMsaAndProvider(fundingSource, delegatorKeys, 'Delegator', FUNDS_AMOUNT);
-        schemaId = new u16(ExtrinsicHelper.api.registry, 0);
-      });
-
-      describe('but has an MSA account that has not been registered as a Provider', function () {
-        it('fails to pay for a transaction', async function () {
-          // Create a keypair with msaId, but no provider
-          const noProviderKeys = await createAndFundKeypair(fundingSource, FUNDS_AMOUNT, 'NoProviderKeys');
-
-          const createMsaOp = ExtrinsicHelper.createMsa(noProviderKeys);
-
-          const { target: msaCreatedEvent } = await createMsaOp.fundAndSend(fundingSource);
-          assert.notEqual(msaCreatedEvent, undefined, 'should have returned MsaCreated event');
-
-          // When a user is not a registered provider and attempts to pay with Capacity,
-          // it should error with InvalidTransaction::Payment, which is a 1010 error, Inability to pay some fees.
-          const payload = await generateDelegationPayload({
-            authorizedMsaId: delegatorProviderId,
-            schemaIds: [schemaId],
-          });
-          const addProviderData = ExtrinsicHelper.api.registry.createType('PalletMsaAddProvider', payload);
-          const grantDelegationOp = ExtrinsicHelper.grantDelegation(
-            delegatorKeys,
-            noProviderKeys,
-            signPayloadSr25519(delegatorKeys, addProviderData),
-            payload
-          );
-
-          await assert.rejects(grantDelegationOp.payWithCapacity('current'), {
-            name: 'RpcError',
-            message: '1010: Invalid Transaction: Inability to pay some fees , e.g. account balance too low',
-          });
-        });
-      });
-
-      describe('and does not have an MSA account associated to signing keys', function () {
-        it('fails to pay for a transaction', async function () {
-          const emptyKeys = await createAndFundKeypair(fundingSource, 50_000_000n);
-
-          const payload = await generateDelegationPayload({
-            authorizedMsaId: delegatorProviderId,
-            schemaIds: [schemaId],
-          });
-          const addProviderData = ExtrinsicHelper.api.registry.createType('PalletMsaAddProvider', payload);
-          const grantDelegationOp = ExtrinsicHelper.grantDelegation(
-            delegatorKeys,
-            emptyKeys,
-            signPayloadSr25519(delegatorKeys, addProviderData),
-            payload
-          );
-
-          await assert.rejects(grantDelegationOp.payWithCapacity('current'), {
-            name: 'RpcError',
-            message: '1010: Invalid Transaction: Custom error: 1',
-          });
         });
       });
     });

--- a/e2e/handles/handles.test.ts
+++ b/e2e/handles/handles.test.ts
@@ -11,7 +11,7 @@ import { hasRelayChain } from '../scaffolding/env';
 import { getFundingSource } from '../scaffolding/funding';
 
 const fundingSource = getFundingSource('handles');
-const expirationOffset = hasRelayChain() ? 10 : 100;
+const expirationOffset = hasRelayChain() ? 4 : 100;
 
 describe('🤝 Handles', function () {
   describe('Claim and Retire', function () {

--- a/e2e/msa/msaKeyManagement.test.ts
+++ b/e2e/msa/msaKeyManagement.test.ts
@@ -174,6 +174,8 @@ describe('MSA Key management', function () {
   describe('provider msa', function () {
     it('should disallow retiring MSA belonging to a provider', async function () {
       const [providerKeys] = await createProviderKeysAndId(fundingSource);
+      // Make sure we are finalized before trying to retire
+      await ExtrinsicHelper.waitForFinalization();
       const retireOp = ExtrinsicHelper.retireMsa(providerKeys);
       await assert.rejects(retireOp.signAndSend('current'), {
         name: 'RpcError',

--- a/e2e/passkey/passkeyProxy.test.ts
+++ b/e2e/passkey/passkeyProxy.test.ts
@@ -13,8 +13,8 @@ describe('Passkey Pallet Tests', function () {
     let fundedKeys: KeyringPair;
     let receiverKeys: KeyringPair;
 
-    beforeEach(async function () {
-      fundedKeys = await createAndFundKeypair(fundingSource, 100_000_000n);
+    before(async function () {
+      fundedKeys = await createAndFundKeypair(fundingSource, 300_000_000n);
       receiverKeys = await createAndFundKeypair(fundingSource);
     });
 
@@ -61,14 +61,14 @@ describe('Passkey Pallet Tests', function () {
     it('should transfer small balance from fundedKeys to receiverKeys', async function () {
       const accountPKey = fundedKeys.publicKey;
       const nonce = await getNonce(fundedKeys);
-      const transferCalls = ExtrinsicHelper.api.tx.balances.transferKeepAlive(receiverKeys.publicKey, 100n);
-      const { passKeyPrivateKey, passKeyPublicKey, passkeySignature } = createPassKeyAndSignAccount(accountPKey);
+      const transferCalls = ExtrinsicHelper.api.tx.balances.transferKeepAlive(receiverKeys.publicKey, 100_000_000n);
+      const { passKeyPrivateKey, passKeyPublicKey } = createPassKeyAndSignAccount(accountPKey);
       const accountSignature = fundedKeys.sign(u8aWrapBytes(passKeyPublicKey));
       const passkeyCall = await createPassKeyCall(accountPKey, nonce, accountSignature, transferCalls);
       const passkeyPayload = await createPasskeyPayload(passKeyPrivateKey, passKeyPublicKey, passkeyCall, false);
       const passkeyProxy = ExtrinsicHelper.executePassKeyProxy(fundedKeys, passkeyPayload);
       assert.doesNotReject(passkeyProxy.fundAndSendUnsigned(fundingSource));
-      await ExtrinsicHelper.waitForFinalization((await getBlockNumber()) + 1);
+      await ExtrinsicHelper.waitForFinalization((await getBlockNumber()) + 2);
       const receiverBalance = await ExtrinsicHelper.getAccountInfo(receiverKeys.address);
       const nonceAfter = (await ExtrinsicHelper.getAccountInfo(fundedKeys.address)).nonce.toNumber();
       assert.equal(nonce + 1, nonceAfter);

--- a/e2e/passkey/passkeyProxy.test.ts
+++ b/e2e/passkey/passkeyProxy.test.ts
@@ -1,6 +1,6 @@
 import '@frequency-chain/api-augment';
 import assert from 'assert';
-import { createAndFundKeypair, getNextEpochBlock, getNonce } from '../scaffolding/helpers';
+import { createAndFundKeypair, getBlockNumber, getNextEpochBlock, getNonce } from '../scaffolding/helpers';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { ExtrinsicHelper } from '../scaffolding/extrinsicHelpers';
 import { getFundingSource } from '../scaffolding/funding';
@@ -68,7 +68,7 @@ describe('Passkey Pallet Tests', function () {
       const passkeyPayload = await createPasskeyPayload(passKeyPrivateKey, passKeyPublicKey, passkeyCall, false);
       const passkeyProxy = ExtrinsicHelper.executePassKeyProxy(fundedKeys, passkeyPayload);
       assert.doesNotReject(passkeyProxy.fundAndSendUnsigned(fundingSource));
-      await ExtrinsicHelper.waitForFinalization();
+      await ExtrinsicHelper.waitForFinalization((await getBlockNumber()) + 2);
       const receiverBalance = await ExtrinsicHelper.getAccountInfo(receiverKeys.address);
       const nonceAfter = await getNonce(fundedKeys);
       assert.equal(nonce + 1, nonceAfter);

--- a/e2e/passkey/passkeyProxy.test.ts
+++ b/e2e/passkey/passkeyProxy.test.ts
@@ -68,9 +68,9 @@ describe('Passkey Pallet Tests', function () {
       const passkeyPayload = await createPasskeyPayload(passKeyPrivateKey, passKeyPublicKey, passkeyCall, false);
       const passkeyProxy = ExtrinsicHelper.executePassKeyProxy(fundedKeys, passkeyPayload);
       assert.doesNotReject(passkeyProxy.fundAndSendUnsigned(fundingSource));
-      await ExtrinsicHelper.waitForFinalization((await getBlockNumber()) + 2);
+      await ExtrinsicHelper.waitForFinalization((await getBlockNumber()) + 1);
       const receiverBalance = await ExtrinsicHelper.getAccountInfo(receiverKeys.address);
-      const nonceAfter = await getNonce(fundedKeys);
+      const nonceAfter = (await ExtrinsicHelper.getAccountInfo(fundedKeys.address)).nonce.toNumber();
       assert.equal(nonce + 1, nonceAfter);
       assert(receiverBalance.data.free.toBigInt() > 0n);
     });

--- a/e2e/passkey/passkeyProxy.test.ts
+++ b/e2e/passkey/passkeyProxy.test.ts
@@ -68,7 +68,7 @@ describe('Passkey Pallet Tests', function () {
       const passkeyPayload = await createPasskeyPayload(passKeyPrivateKey, passKeyPublicKey, passkeyCall, false);
       const passkeyProxy = ExtrinsicHelper.executePassKeyProxy(fundedKeys, passkeyPayload);
       assert.doesNotReject(passkeyProxy.fundAndSendUnsigned(fundingSource));
-      await ExtrinsicHelper.runToBlock(await getNextEpochBlock());
+      await ExtrinsicHelper.waitForFinalization();
       const receiverBalance = await ExtrinsicHelper.getAccountInfo(receiverKeys.address);
       const nonceAfter = await getNonce(fundedKeys);
       assert.equal(nonce + 1, nonceAfter);

--- a/e2e/scaffolding/funding.ts
+++ b/e2e/scaffolding/funding.ts
@@ -14,6 +14,7 @@ export const fundingSources = [
   'capacity-staking',
   'capacity-transactions',
   'capacity-transactions-batch',
+  'capacity-transactions-fail',
   'capacity-unstaking',
   'check-metadata-hash',
   'frequency-misc',

--- a/e2e/scaffolding/helpers.ts
+++ b/e2e/scaffolding/helpers.ts
@@ -78,6 +78,10 @@ export async function generateDelegationPayload(
   };
 }
 
+export async function getFinalizedBlockNumber(): Promise<number> {
+  return (await ExtrinsicHelper.getLastFinalizedBlock()).block.header.number.toNumber();
+}
+
 export async function getBlockNumber(): Promise<number> {
   return (await ExtrinsicHelper.getLastBlock()).block.header.number.toNumber();
 }

--- a/e2e/signed-extensions/checkMetadataHash.test.ts
+++ b/e2e/signed-extensions/checkMetadataHash.test.ts
@@ -19,6 +19,7 @@ const fundingSource = getFundingSource('check-metadata-hash');
 // This is skipped as it requires the e2e tests to be run
 // against a Frequency build that has the metadata-hash feature
 // enabled. That feature is a large increase in compile time however.
+// eslint-disable-next-line mocha/no-skipped-tests
 describe.skip('Check Metadata Hash', function () {
   let keys: KeyringPair;
   let accountWithNoFunds: KeyringPair;


### PR DESCRIPTION
# Goal
The goal of this PR is to add a final set of e2e test improvements to allow e2e tests to run against testnet again post async-backing

Closes #2154 

# Discussion

- Added a way to wait for finalization
- Added errors instead of waiting forever for blocks
- Reduced timeouts thanks to 6s blocktimes on testnet
- Split up more tests for better parallelization

# Testing

- https://github.com/frequency-chain/frequency/actions/runs/11489493946/job/31978401849