### PR TITLE
Switch the sourcing of the funds from strings to test file names

### DIFF
--- a/e2e/capacity/capacityFail.test.ts
+++ b/e2e/capacity/capacityFail.test.ts
@@ -22,7 +22,7 @@ import { getFundingSource } from '../scaffolding/funding';
 import { getUnifiedPublicKey } from '../scaffolding/ethereum';
 
 const FUNDS_AMOUNT: bigint = 50n * DOLLARS;
-const fundingSource = getFundingSource('capacity-transactions-fail');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('Capacity Transaction Failures', function () {
   describe('pay_with_capacity', function () {

--- a/e2e/capacity/capacity_rpc.test.ts
+++ b/e2e/capacity/capacity_rpc.test.ts
@@ -16,7 +16,7 @@ import { getFundingSource } from '../scaffolding/funding';
 import { getUnifiedPublicKey } from '../scaffolding/ethereum';
 
 const FUNDS_AMOUNT: bigint = 50n * DOLLARS;
-const fundingSource = getFundingSource('capacity-rpcs');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('Capacity RPC', function () {
   let capacityProviderKeys: KeyringPair;

--- a/e2e/capacity/change_staking_target.test.ts
+++ b/e2e/capacity/change_staking_target.test.ts
@@ -11,7 +11,7 @@ import {
   createProviderKeysAndId,
 } from '../scaffolding/helpers';
 
-const fundingSource = getFundingSource('capacity-change-staking-target');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('Capacity: change_staking_target', function () {
   const tokenMinStake: bigint = 1n * CENTS;

--- a/e2e/capacity/list_unclaimed_rewards.test.ts
+++ b/e2e/capacity/list_unclaimed_rewards.test.ts
@@ -14,7 +14,7 @@ import { isTestnet } from '../scaffolding/env';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { getUnifiedAddress } from '../scaffolding/ethereum';
 
-const fundingSource = getFundingSource('capacity-list-unclaimed-rewards');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('Capacity: list_unclaimed_rewards', function () {
   const providerBalance = 2n * DOLLARS;

--- a/e2e/capacity/provider_boost.test.ts
+++ b/e2e/capacity/provider_boost.test.ts
@@ -11,7 +11,7 @@ import {
   stakeToProvider,
 } from '../scaffolding/helpers';
 
-const fundingSource = getFundingSource('capacity-provider-boost');
+const fundingSource = getFundingSource(import.meta.url);
 const tokenMinStake: bigint = 1n * CENTS;
 
 describe('Capacity: provider_boost extrinsic', function () {

--- a/e2e/capacity/replenishment.test.ts
+++ b/e2e/capacity/replenishment.test.ts
@@ -20,7 +20,7 @@ import {
 import { getFundingSource } from '../scaffolding/funding';
 import { isTestnet } from '../scaffolding/env';
 
-const fundingSource = getFundingSource('capacity-replenishment');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('Capacity Replenishment Testing: ', function () {
   async function createAndStakeProvider(name: string, stakingAmount: bigint): Promise<[KeyringPair, u64]> {

--- a/e2e/capacity/staking.test.ts
+++ b/e2e/capacity/staking.test.ts
@@ -21,7 +21,7 @@ import { getFundingSource } from '../scaffolding/funding';
 const accountBalance: bigint = 2n * DOLLARS;
 const tokenMinStake: bigint = 1n * CENTS;
 const capacityMin: bigint = tokenMinStake / 50n;
-const fundingSource = getFundingSource('capacity-staking');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('Capacity Staking Tests', function () {
   // The frozen balance is initialized and tracked throughout the staking end to end tests

--- a/e2e/capacity/transactions.test.ts
+++ b/e2e/capacity/transactions.test.ts
@@ -41,7 +41,7 @@ import { getFundingSource } from '../scaffolding/funding';
 import { getUnifiedPublicKey } from '../scaffolding/ethereum';
 
 const FUNDS_AMOUNT: bigint = 50n * DOLLARS;
-const fundingSource = getFundingSource('capacity-transactions');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('Capacity Transactions', function () {
   describe('pay_with_capacity', function () {

--- a/e2e/capacity/transactionsBatch.test.ts
+++ b/e2e/capacity/transactionsBatch.test.ts
@@ -19,7 +19,7 @@ import { getFundingSource } from '../scaffolding/funding';
 import { getUnifiedPublicKey } from '../scaffolding/ethereum';
 
 const FUNDS_AMOUNT: bigint = 50n * DOLLARS;
-const fundingSource = getFundingSource('capacity-transactions-batch');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('Capacity Transactions Batch', function () {
   describe('pay_with_capacity_batch_all', function () {

--- a/e2e/capacity/unstaking.test.ts
+++ b/e2e/capacity/unstaking.test.ts
@@ -8,7 +8,7 @@ import { getFundingSource } from '../scaffolding/funding';
 
 const accountBalance: bigint = 2n * DOLLARS;
 const tokenMinStake: bigint = 1n * CENTS;
-const fundingSource = getFundingSource('capacity-unstaking');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('Capacity Unstaking Tests', function () {
   describe('unstake()', function () {

--- a/e2e/handles/handles.test.ts
+++ b/e2e/handles/handles.test.ts
@@ -10,7 +10,7 @@ import { getBlockNumber } from '../scaffolding/helpers';
 import { hasRelayChain } from '../scaffolding/env';
 import { getFundingSource } from '../scaffolding/funding';
 
-const fundingSource = getFundingSource('handles');
+const fundingSource = getFundingSource(import.meta.url);
 const expirationOffset = hasRelayChain() ? 4 : 100;
 
 describe('🤝 Handles', function () {

--- a/e2e/load-tests/signatureRegistry.test.ts
+++ b/e2e/load-tests/signatureRegistry.test.ts
@@ -90,7 +90,7 @@ async function checkKeys(startingNumber: number, keysToTest: KeyringPair[]) {
 async function generateMsas(count: number = 1): Promise<GeneratedMsa[]> {
   // Make sure we are not on an edge
   const createBlockEvery = count === 300 ? 290 : 300;
-  const fundingSource = getFundingSource('load-signature-registry');
+  const fundingSource = getFundingSource(import.meta.url);
 
   // Create and fund the control keys
   const controlKeyPromises: Promise<KeyringPair>[] = [];

--- a/e2e/messages/addIPFSMessage.test.ts
+++ b/e2e/messages/addIPFSMessage.test.ts
@@ -11,7 +11,7 @@ import { u16 } from '@polkadot/types';
 import { ipfsCid } from './ipfs';
 import { getFundingSource } from '../scaffolding/funding';
 
-const fundingSource = getFundingSource('messages-add-ipfs');
+const fundingSource = getFundingSource(import.meta.url);
 const ipfs_payload_data = 'This is a test of Frequency.';
 const ipfs_payload_len = ipfs_payload_data.length + 1;
 

--- a/e2e/miscellaneous/balance.ethereum.test.ts
+++ b/e2e/miscellaneous/balance.ethereum.test.ts
@@ -6,7 +6,7 @@ import { Extrinsic, ExtrinsicHelper } from '../scaffolding/extrinsicHelpers';
 import { getFundingSource } from '../scaffolding/funding';
 import { getUnifiedAddress } from '../scaffolding/ethereum';
 
-const fundingSource: KeyringPair = getFundingSource('frequency-balance-ethereum');
+const fundingSource: KeyringPair = getFundingSource(import.meta.url);
 
 describe('Balance transfer ethereum', function () {
   describe('setup', function () {

--- a/e2e/miscellaneous/frequency.test.ts
+++ b/e2e/miscellaneous/frequency.test.ts
@@ -8,7 +8,7 @@ import { u8, Option } from '@polkadot/types';
 import { u8aToHex } from '@polkadot/util/u8a/toHex';
 import { getUnifiedAddress, getUnifiedPublicKey } from '../scaffolding/ethereum';
 
-const fundingSource: KeyringPair = getFundingSource('frequency-misc');
+const fundingSource: KeyringPair = getFundingSource(import.meta.url);
 
 describe('Frequency', function () {
   describe('setup', function () {

--- a/e2e/miscellaneous/utilityBatch.test.ts
+++ b/e2e/miscellaneous/utilityBatch.test.ts
@@ -6,7 +6,7 @@ import { ApiTypes, SubmittableExtrinsic } from '@polkadot/api/types';
 import { getFundingSource } from '../scaffolding/funding';
 import { getUnifiedAddress } from '../scaffolding/ethereum';
 
-const fundingSource = getFundingSource('misc-util-batch');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('Utility Batch Filtering', function () {
   let sender: KeyringPair;

--- a/e2e/msa/createMsa.test.ts
+++ b/e2e/msa/createMsa.test.ts
@@ -5,7 +5,7 @@ import { KeyringPair } from '@polkadot/keyring/types';
 import { ExtrinsicHelper } from '../scaffolding/extrinsicHelpers';
 import { getFundingSource } from '../scaffolding/funding';
 
-const fundingSource = getFundingSource('msa-create-msa');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('Create Accounts', function () {
   let keys: KeyringPair;

--- a/e2e/msa/keyManagement.ethereum.test.ts
+++ b/e2e/msa/keyManagement.ethereum.test.ts
@@ -16,7 +16,7 @@ import { getFundingSource } from '../scaffolding/funding';
 import { getUnifiedPublicKey } from '../scaffolding/ethereum';
 
 const maxU64 = 18_446_744_073_709_551_615n;
-const fundingSource = getFundingSource('msa-key-management-ethereum');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('MSA Key management Ethereum', function () {
   describe('addPublicKeyToMsa Ethereum', function () {

--- a/e2e/msa/msaKeyManagement.test.ts
+++ b/e2e/msa/msaKeyManagement.test.ts
@@ -17,7 +17,7 @@ import { getFundingSource } from '../scaffolding/funding';
 import { getUnifiedPublicKey } from '../scaffolding/ethereum';
 
 const maxU64 = 18_446_744_073_709_551_615n;
-const fundingSource = getFundingSource('msa-key-management');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('MSA Key management', function () {
   describe('addPublicKeyToMsa', function () {

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -28,6 +28,7 @@
         "@types/workerpool": "^6.4.7",
         "eslint": "^9.16.0",
         "eslint-plugin-mocha": "^10.5.0",
+        "glob": "^11.0.0",
         "globals": "^15.13.0",
         "mocha": "^11.0.1",
         "prettier": "^3.4.1",
@@ -4668,6 +4669,27 @@
         "@babel/preset-env": "^7.1.6"
       }
     },
+    "node_modules/@react-native/codegen/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@react-native/community-cli-plugin": {
       "version": "0.75.4",
       "license": "MIT",
@@ -7171,7 +7193,8 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "peer": true
     },
     "node_modules/fsevents": {
@@ -7249,19 +7272,23 @@
       "license": "MIT"
     },
     "node_modules/glob": {
-      "version": "7.2.3",
-      "license": "ISC",
-      "peer": true,
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
+      "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
+      "dev": true,
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": "*"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -7276,6 +7303,61 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/jackspeak": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
+      "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/lru-cache": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+      "dev": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -7484,7 +7566,9 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "peer": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -9943,7 +10027,8 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10489,6 +10574,27 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/react-native/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/react-native/node_modules/ws": {
       "version": "6.2.3",
       "license": "MIT",
@@ -10725,6 +10831,27 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -11401,6 +11528,27 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/temp/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/temp/node_modules/rimraf": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -36,6 +36,7 @@
     "@types/workerpool": "^6.4.7",
     "eslint": "^9.16.0",
     "eslint-plugin-mocha": "^10.5.0",
+    "glob": "^11.0.0",
     "globals": "^15.13.0",
     "mocha": "^11.0.1",
     "prettier": "^3.4.1",

--- a/e2e/passkey/passkeyProxy.ethereum.test.ts
+++ b/e2e/passkey/passkeyProxy.ethereum.test.ts
@@ -13,7 +13,7 @@ import { getFundingSource } from '../scaffolding/funding';
 import { getUnifiedPublicKey, getUnifiedAddress } from '../scaffolding/ethereum';
 import { createPassKeyAndSignAccount, createPassKeyCall, createPasskeyPayload } from '../scaffolding/P256';
 import { u8aToHex, u8aWrapBytes } from '@polkadot/util';
-const fundingSource = getFundingSource('passkey-proxy-ethereum');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('Passkey Pallet Ethereum Tests', function () {
   describe('passkey ethereum tests', function () {

--- a/e2e/passkey/passkeyProxy.test.ts
+++ b/e2e/passkey/passkeyProxy.test.ts
@@ -13,7 +13,7 @@ import { getFundingSource } from '../scaffolding/funding';
 import { u8aToHex, u8aWrapBytes } from '@polkadot/util';
 import { createPassKeyAndSignAccount, createPassKeyCall, createPasskeyPayload } from '../scaffolding/P256';
 import { getUnifiedPublicKey } from '../scaffolding/ethereum';
-const fundingSource = getFundingSource('passkey-proxy');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('Passkey Pallet Tests', function () {
   describe('proxy basic tests', function () {

--- a/e2e/proxy-pallet/proxy.test.ts
+++ b/e2e/proxy-pallet/proxy.test.ts
@@ -8,7 +8,7 @@ import { getUnifiedAddress } from '../scaffolding/ethereum';
 
 const DOLLARS = 100000000n; // 100_000_000
 
-const fundingSource: KeyringPair = getFundingSource('proxy-pallet');
+const fundingSource: KeyringPair = getFundingSource(import.meta.url);
 
 describe('Proxy', function () {
   describe('Basic Any Proxy Successes', function () {

--- a/e2e/scenarios/grantDelegation.ethereum.test.ts
+++ b/e2e/scenarios/grantDelegation.ethereum.test.ts
@@ -13,7 +13,7 @@ import {
 import { SchemaId } from '@frequency-chain/api-augment/interfaces';
 import { getFundingSource } from '../scaffolding/funding';
 
-const fundingSource = getFundingSource('grant-delegation-ethereum');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('Delegation Scenario Tests Ethereum', function () {
   let keys: KeyringPair;

--- a/e2e/scenarios/grantDelegation.test.ts
+++ b/e2e/scenarios/grantDelegation.test.ts
@@ -16,7 +16,7 @@ import {
 import { SchemaGrantResponse, SchemaId } from '@frequency-chain/api-augment/interfaces';
 import { getFundingSource } from '../scaffolding/funding';
 
-const fundingSource = getFundingSource('scenarios-grant-delegation');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('Delegation Scenario Tests', function () {
   let keys: KeyringPair;

--- a/e2e/schemas/createSchema.test.ts
+++ b/e2e/schemas/createSchema.test.ts
@@ -13,7 +13,7 @@ import {
 } from '../scaffolding/helpers';
 import { getFundingSource } from '../scaffolding/funding';
 
-const fundingSource = getFundingSource('schemas-create');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('#createSchema', function () {
   let keys: KeyringPair;

--- a/e2e/signed-extensions/checkMetadataHash.test.ts
+++ b/e2e/signed-extensions/checkMetadataHash.test.ts
@@ -15,7 +15,7 @@ import { getFundingSource } from '../scaffolding/funding';
 import { u8aToHex } from '@polkadot/util';
 import { getUnifiedAddress } from '../scaffolding/ethereum';
 
-const fundingSource = getFundingSource('check-metadata-hash');
+const fundingSource = getFundingSource(import.meta.url);
 
 // This is skipped as it requires the e2e tests to be run
 // against a Frequency build that has the metadata-hash feature

--- a/e2e/stateful-pallet-storage/handleItemized.test.ts
+++ b/e2e/stateful-pallet-storage/handleItemized.test.ts
@@ -16,7 +16,7 @@ import { MessageSourceId, SchemaId } from '@frequency-chain/api-augment/interfac
 import { Bytes, u16, u64 } from '@polkadot/types';
 import { getFundingSource } from '../scaffolding/funding';
 
-const fundingSource = getFundingSource('stateful-storage-handle-itemized');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('📗 Stateful Pallet Storage Itemized', function () {
   let schemaId_deletable: SchemaId;

--- a/e2e/stateful-pallet-storage/handlePaginated.test.ts
+++ b/e2e/stateful-pallet-storage/handlePaginated.test.ts
@@ -17,7 +17,7 @@ import { Bytes, u16, u64 } from '@polkadot/types';
 import { getFundingSource } from '../scaffolding/funding';
 
 const badSchemaId = 65_534;
-const fundingSource = getFundingSource('stateful-storage-handle-paginated');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('📗 Stateful Pallet Storage Paginated', function () {
   let schemaId: SchemaId;

--- a/e2e/stateful-pallet-storage/handleSignatureRequired.test.ts
+++ b/e2e/stateful-pallet-storage/handleSignatureRequired.test.ts
@@ -23,7 +23,7 @@ import { MessageSourceId, SchemaId } from '@frequency-chain/api-augment/interfac
 import { Bytes, u16 } from '@polkadot/types';
 import { getFundingSource } from '../scaffolding/funding';
 
-const fundingSource = getFundingSource('stateful-storage-handle-sig-req');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('📗 Stateful Pallet Storage Signature Required', function () {
   let itemizedSchemaId: SchemaId;

--- a/e2e/stateful-pallet-storage/stateful.ethereum.test.ts
+++ b/e2e/stateful-pallet-storage/stateful.ethereum.test.ts
@@ -19,7 +19,7 @@ import { MessageSourceId, SchemaId } from '@frequency-chain/api-augment/interfac
 import { Bytes, u16 } from '@polkadot/types';
 import { getFundingSource } from '../scaffolding/funding';
 
-const fundingSource = getFundingSource('stateful-storage-ethereum');
+const fundingSource = getFundingSource(import.meta.url);
 
 describe('📗 Stateful Pallet Storage Ethereum', function () {
   let itemizedSchemaId: SchemaId;

--- a/e2e/sudo/sudo.test.ts
+++ b/e2e/sudo/sudo.test.ts
@@ -28,7 +28,7 @@ describe('Sudo required', function () {
   before(function () {
     if (isTestnet()) this.skip();
     sudoKey = getSudo().keys;
-    fundingSource = getFundingSource('sudo-transactions');
+    fundingSource = getFundingSource(import.meta.url);
   });
 
   describe('schema#setMaxSchemaModelBytes', function () {

--- a/e2e/time-release/timeRelease.test.ts
+++ b/e2e/time-release/timeRelease.test.ts
@@ -31,7 +31,7 @@ function calculateReleaseSchedule(amount: number | bigint): ReleaseSchedule {
   };
 }
 
-const fundingSource: KeyringPair = getFundingSource('time-release');
+const fundingSource: KeyringPair = getFundingSource(import.meta.url);
 
 describe('TimeRelease', function () {
   let vesterKeys: KeyringPair;


### PR DESCRIPTION
Note: This will merge into the feature branch `e2e-improvements-development`

# Goal

Simple swap from string to file name and path based account funding for tests

## Checking

- Tests all still run!
- Stopping the tests means that some accounts don't have to be topped off in the re-run