### PR TITLE
Fix CI Tera Issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -688,8 +688,9 @@ jobs:
         run: |
           echo "PREVIOUS_RELEASE_TAG=${{steps.get-previous-full-release-version.outputs.version}}" >> $GITHUB_ENV
       - name: Install Tera CLI
+        # TODO: Update to v0.5.0 once Rust version is > 1.83.0
         run: |
-          cargo install --locked --git https://github.com/chevdor/tera-cli
+          cargo install --locked --git https://github.com/chevdor/tera-cli --tag v0.4.0
           echo "PATH=$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV
       - name: Verify Tera CLI Install
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16069,3 +16069,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "fflonk"
+version = "0.1.1"
+source = "git+https://www.github.com/w3f/fflonk?rev=be95d4c971b1d15b5badfc06ff13f5c07987d484#be95d4c971b1d15b5badfc06ff13f5c07987d484"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6468,9 +6468,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
@@ -6509,9 +6509,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,10 @@ substrate-frame-rpc-system = { git = "https://github.com/paritytech/polkadot-sdk
 substrate-prometheus-endpoint = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.13.0" }
 sp-debug-derive = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.13.0", default-features = false }
 
+# hotfix for https://github.com/paritytech/polkadot-sdk/issues/7653
+[patch.'https://github.com/w3f/fflonk']
+fflonk = { git = "https://www.github.com/w3f/fflonk", rev = "be95d4c971b1d15b5badfc06ff13f5c07987d484" }
+
 [profile.release]
 panic = "unwind"
 lto = true

--- a/deny.toml
+++ b/deny.toml
@@ -64,19 +64,23 @@ feature-depth = 1
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
 ignore = [
-  #"RUSTSEC-0000-0000",
-  #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
-  #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
-  #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
-  { id = "RUSTSEC-2022-0061", reason = "Substrate Dependency deprecation. Eventually there will be an update. See https://github.com/paritytech/parity-wasm/pull/334 and https://github.com/paritytech/polkadot-sdk/issues/118" },
-  { id = "RUSTSEC-2021-0139", reason = "Substrate dependency deprecation. See https://github.com/paritytech/polkadot-sdk/issues/31" },
-  { id = "RUSTSEC-2020-0168", reason = "There is no suitable replacement for mach and the mach2 crate has not been vetted." },
-  { id = "RUSTSEC-2024-0336", reason = "Only use of rustls@v0.20.9 is in futures-rustls which does not use the effected code" },
-  { id = "RUSTSEC-2024-0344", reason = "We are only able to remove this once parity updates its dependencies. Older versions of curve25519-dalek should get replaces with >= 4.1.3" },
-  { id = "RUSTSEC-2022-0093", reason = "The vulnerable code is not exploitable in Frequency because the signing function is not exposed in a way that allows the use of arbitrary public keys, ensuring protection against the described vulnerability." },
-  { id = "RUSTSEC-2024-0370", reason = "proc-macro-error is used by a few dependencies, and while unmaintained, is not currently an issue." },
-  { id = "RUSTSEC-2024-0388", reason = "This is an inner dependency that would get updated when cumulus-primitives-core v0.7.0 is updated to a newer version"},
-  { id = "RUSTSEC-2024-0384", reason = "This is an inner dependency that would get updated when libp2p v0.51.4 and wasm-timer v0.2.5 are updated to a newer version"},
+	#"RUSTSEC-0000-0000",
+	#{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
+	#"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
+	#{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
+	{ id = "RUSTSEC-2022-0061", reason = "Substrate Dependency deprecation. Eventually there will be an update. See https://github.com/paritytech/parity-wasm/pull/334 and https://github.com/paritytech/polkadot-sdk/issues/118" },
+	{ id = "RUSTSEC-2021-0139", reason = "Substrate dependency deprecation. See https://github.com/paritytech/polkadot-sdk/issues/31" },
+	{ id = "RUSTSEC-2020-0168", reason = "There is no suitable replacement for mach and the mach2 crate has not been vetted." },
+	{ id = "RUSTSEC-2024-0336", reason = "Only use of rustls@v0.20.9 is in futures-rustls which does not use the effected code" },
+	{ id = "RUSTSEC-2024-0344", reason = "We are only able to remove this once parity updates its dependencies. Older versions of curve25519-dalek should get replaces with >= 4.1.3" },
+	{ id = "RUSTSEC-2022-0093", reason = "The vulnerable code is not exploitable in Frequency because the signing function is not exposed in a way that allows the use of arbitrary public keys, ensuring protection against the described vulnerability." },
+	{ id = "RUSTSEC-2024-0370", reason = "proc-macro-error is used by a few dependencies, and while unmaintained, is not currently an issue." },
+	{ id = "RUSTSEC-2024-0388", reason = "This is an inner dependency that would get updated when cumulus-primitives-core v0.7.0 is updated to a newer version" },
+	{ id = "RUSTSEC-2024-0384", reason = "This is an inner dependency that would get updated when libp2p v0.51.4 and wasm-timer v0.2.5 are updated to a newer version" },
+	{ id = "RUSTSEC-2024-0421", reason = "The vulnerable code is not exploitable in Frequency as the problem code is unused." },
+	{ id = "RUSTSEC-2025-0010", reason = "Substrate dependency unmaintained. Waiting for a new version of the Polkadot-SDK." },
+	{ id = "RUSTSEC-2025-0009", reason = "Substrate dependency unmaintained. Waiting for a new version of the Polkadot-SDK." },
+	{ id = "RUSTSEC-2024-0436", reason = "Substrate dependency unmaintained. Waiting for a new version of the Polkadot-SDK." },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
@@ -92,20 +96,19 @@ ignore = [
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
-  "MIT",
-  "Apache-2.0",
-  "Apache-2.0 WITH LLVM-exception",
-  "BSD-2-Clause",
-  "BSD-3-Clause",
-  "CC0-1.0",
-  "MPL-2.0",
-  "ISC",
-  "GPL-3.0",
-  "GPL-3.0 WITH Classpath-exception-2.0",
-  "OpenSSL",
-  "Unicode-DFS-2016",
-  "Zlib",
-  "Unicode-3.0",
+	"MIT",
+	"Apache-2.0",
+	"Apache-2.0 WITH LLVM-exception",
+	"BSD-2-Clause",
+	"BSD-3-Clause",
+	"CC0-1.0",
+	"MPL-2.0",
+	"ISC",
+	"GPL-3.0",
+	"GPL-3.0 WITH Classpath-exception-2.0",
+	"OpenSSL",
+	"Unicode-DFS-2016",
+	"Zlib",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
+# TODO: Update Tera in CI to v0.5.0 once Rust version is > 1.83.0
 [toolchain]
 channel = "1.76.0"
 components = [ "clippy", "rust-docs", "rustfmt","rustc-dev", "rustc", "rust-src"]


### PR DESCRIPTION
# Goal
The goal of this PR is to pin the release notes tool Tera as the newest version is not supported by our current Rust version

See failure: https://github.com/frequency-chain/frequency/actions/runs/13769786316/job/38512084491

- Pin Tera (and note the TODOs)
- Fix Cargo Deny issues