### PR TITLE
fixes double charge, undo changes to increase balances in e2e tests

### DIFF
--- a/common/primitives/src/capacity.rs
+++ b/common/primitives/src/capacity.rs
@@ -28,6 +28,9 @@ pub trait Nontransferable {
 	/// The available Capacity for an MSA.
 	fn balance(msa_id: MessageSourceId) -> Self::Balance;
 
+	/// The replenishable Capacity for an MSA (the total capacity currently issued)
+	fn replenishable_balance(msa_id: MessageSourceId) -> Self::Balance;
+
 	/// Reduce Capacity of an MSA by amount.
 	fn deduct(msa_id: MessageSourceId, capacity_amount: Self::Balance)
 		-> Result<(), DispatchError>;

--- a/e2e/capacity/staking.test.ts
+++ b/e2e/capacity/staking.test.ts
@@ -246,7 +246,7 @@ describe('Capacity Staking Tests', function () {
   describe('when staking and targeting an InvalidTarget', function () {
     it('fails to stake', async function () {
       const stakeAmount = 10n * CENTS;
-      const [notProviderMsaId, stakeKeys] = await createMsa(fundingSource, 1n * DOLLARS);
+      const [notProviderMsaId, stakeKeys] = await createMsa(fundingSource, 10n * CENTS);
 
       const failStakeObj = ExtrinsicHelper.stake(stakeKeys, notProviderMsaId, stakeAmount);
       await assert.rejects(failStakeObj.signAndSend(), { name: 'InvalidTarget' });
@@ -267,7 +267,7 @@ describe('Capacity Staking Tests', function () {
   describe('when attempting to stake a zero amount', function () {
     it('fails to stake and errors ZeroAmountNotAllowed', async function () {
       const stakingKeys = createKeys('stakingKeys');
-      const providerId = await createMsaAndProvider(fundingSource, stakingKeys, 'stakingKeys', 30n * CENTS);
+      const providerId = await createMsaAndProvider(fundingSource, stakingKeys, 'stakingKeys', 10n * CENTS);
 
       const failStakeObj = ExtrinsicHelper.stake(stakingKeys, providerId, 0);
       await assert.rejects(failStakeObj.signAndSend(), { name: 'ZeroAmountNotAllowed' });

--- a/e2e/capacity/transactions.test.ts
+++ b/e2e/capacity/transactions.test.ts
@@ -217,9 +217,7 @@ describe('Capacity Transactions', function () {
           assert.notEqual(delegatorProviderId, undefined, 'setup should populate msa_id');
 
           // Stake the amount for each test
-          // TODO: running out of funds, adding 1 to cover Capacity cost, should debug to see if
-          // there is something else going on.
-          const numberOfTests = BigInt(this.test!.parent!.tests.length) + 1n;
+          const numberOfTests = BigInt(this.test!.parent!.tests.length);
           await assert.doesNotReject(
             stakeToProvider(fundingSource, fundingSource, capacityProvider, numberOfTests * amountStaked)
           );

--- a/e2e/handles/handles.test.ts
+++ b/e2e/handles/handles.test.ts
@@ -71,7 +71,7 @@ describe('🤝 Handles', function () {
 
     before(async function () {
       // Create a MSA for the delegator
-      [msa_id, msaOwnerKeys] = await createMsa(fundingSource, 1n * DOLLARS);
+      [msa_id, msaOwnerKeys] = await createMsa(fundingSource);
       assert.notEqual(msaOwnerKeys, undefined, 'setup should populate delegator_key');
       assert.notEqual(msa_id, undefined, 'setup should populate msa_id');
     });

--- a/e2e/msa/msaKeyManagement.test.ts
+++ b/e2e/msa/msaKeyManagement.test.ts
@@ -33,7 +33,7 @@ describe('MSA Key management', function () {
 
     before(async function () {
       // Setup an MSA with one key and a secondary funded key
-      keys = await createAndFundKeypair(fundingSource, 1n * DOLLARS);
+      keys = await createAndFundKeypair(fundingSource, 5n * CENTS);
       const { target } = await ExtrinsicHelper.createMsa(keys).signAndSend();
       assert.notEqual(target?.data.msaId, undefined, 'MSA Id not in expected event');
       msaId = target!.data.msaId;

--- a/e2e/scaffolding/extrinsicHelpers.ts
+++ b/e2e/scaffolding/extrinsicHelpers.ts
@@ -259,7 +259,7 @@ export class Extrinsic<N = unknown, T extends ISubmittableResult = ISubmittableR
     return firstValueFrom(
       this.extrinsic()
         .paymentInfo(getUnifiedAddress(this.keys))
-        .pipe(map((info) => info.partialFee.toBigInt() * 2n))
+        .pipe(map((info) => info.partialFee.toBigInt()))
     );
   }
 

--- a/e2e/scaffolding/helpers.ts
+++ b/e2e/scaffolding/helpers.ts
@@ -293,11 +293,11 @@ export async function drainKeys(keyPairs: KeyringPair[], dest: KeyringPair) {
         const info = await ExtrinsicHelper.getAccountInfo(keypair);
         // Only drain keys that can be
         if (canDrainAccount(info)) await ExtrinsicHelper.emptyAccount(keypair, dest).signAndSend();
-      }),
+      })
     );
-  } catch (e) {
+        } catch (e) {
     console.log('Error draining accounts: ', e);
-  }
+        }
 }
 
 export async function fundKeypair(
@@ -365,7 +365,7 @@ export async function createDelegatorAndDelegation(
   keyType: KeypairType = 'sr25519',
 ): Promise<[KeyringPair, u64]> {
   // Create a  delegator msa + keys.
-  const [delegatorMsaId, delegatorKeys] = await createMsa(source, 2n * DOLLARS, keyType);
+  const [delegatorMsaId, delegatorKeys] = await createMsa(source, undefined, keyType);
   // Grant delegation to the provider
   const payload = await generateDelegationPayload({
     authorizedMsaId: providerId,

--- a/e2e/scaffolding/helpers.ts
+++ b/e2e/scaffolding/helpers.ts
@@ -295,9 +295,9 @@ export async function drainKeys(keyPairs: KeyringPair[], dest: KeyringPair) {
         if (canDrainAccount(info)) await ExtrinsicHelper.emptyAccount(keypair, dest).signAndSend();
       })
     );
-        } catch (e) {
+  } catch (e) {
     console.log('Error draining accounts: ', e);
-        }
+  }
 }
 
 export async function fundKeypair(

--- a/e2e/stateful-pallet-storage/handleSignatureRequired.test.ts
+++ b/e2e/stateful-pallet-storage/handleSignatureRequired.test.ts
@@ -91,7 +91,6 @@ describe('📗 Stateful Pallet Storage Signature Required', function () {
   });
 
   describe('Itemized With Signature Storage Tests', function () {
-    // passes
     it('provider should be able to call applyItemizedActionWithSignature and apply actions', async function () {
       const { payload, signature } = itemizedActionsSignedPayload;
 
@@ -112,9 +111,16 @@ describe('📗 Stateful Pallet Storage Signature Required', function () {
       );
     });
 
-    // fails
     it('delegator (owner) should be able to call applyItemizedActionWithSignature and apply actions', async function () {
-      const { payload, signature } = itemizedActionsSignedPayload;
+    const { payload, signature } = await generateItemizedActionsSignedPayload(
+        generateItemizedActions([
+          { action: 'Add', value: 'Hello, world from Frequency' },
+          { action: 'Add', value: 'Hello, world again from Frequency' },
+        ]),
+        itemizedSchemaId,
+        delegatorKeys,
+        msa_id
+    );
 
       const itemized_add_result_1 = ExtrinsicHelper.applyItemActionsWithSignature(
         delegatorKeys,

--- a/e2e/stateful-pallet-storage/handleSignatureRequired.test.ts
+++ b/e2e/stateful-pallet-storage/handleSignatureRequired.test.ts
@@ -504,7 +504,6 @@ describe('📗 Stateful Pallet Storage Signature Required', function () {
       await assert.rejects(upsert_2.fundAndSend(fundingSource), { name: 'UnsupportedOperationForSchema' });
     });
 
-    // fails but not when called individually?
     it('owner can upsertPage', async function () {
       const page_id = new u16(ExtrinsicHelper.api.registry, 1);
 
@@ -518,7 +517,6 @@ describe('📗 Stateful Pallet Storage Signature Required', function () {
         new Bytes(ExtrinsicHelper.api.registry, 'Hello World From Frequency'),
         target_hash
       );
-      console.log("about to fund and send");
       const { target: pageUpdateEvent, eventMap: chainEvents1 } = await upsert_result.fundAndSend(fundingSource);
       assertExtrinsicSucceededAndFeesPaid(chainEvents1);
       assert.notEqual(

--- a/node/service/src/block_sealing.rs
+++ b/node/service/src/block_sealing.rs
@@ -191,7 +191,6 @@ pub fn start_frequency_dev_sealing_node(
 				pool: transaction_pool.clone(),
 				command_sink: command_sink.clone(),
 			};
-
 			crate::rpc::create_full(deps, backend.clone()).map_err(Into::into)
 		})
 	};

--- a/node/service/src/block_sealing.rs
+++ b/node/service/src/block_sealing.rs
@@ -191,6 +191,7 @@ pub fn start_frequency_dev_sealing_node(
 				pool: transaction_pool.clone(),
 				command_sink: command_sink.clone(),
 			};
+
 			crate::rpc::create_full(deps, backend.clone()).map_err(Into::into)
 		})
 	};

--- a/pallets/capacity/src/lib.rs
+++ b/pallets/capacity/src/lib.rs
@@ -1237,6 +1237,13 @@ impl<T: Config> Nontransferable for Pallet<T> {
 		}
 	}
 
+	fn replenishable_balance(msa_id: MessageSourceId) -> Self::Balance {
+		match CapacityLedger::<T>::get(msa_id) {
+			Some(capacity_details) => capacity_details.total_capacity_issued,
+			None => BalanceOf::<T>::zero(),
+		}
+	}
+
 	/// Spend capacity: reduce remaining capacity by the given amount
 	fn deduct(msa_id: MessageSourceId, amount: Self::Balance) -> Result<(), DispatchError> {
 		let mut capacity_details =

--- a/pallets/frequency-tx-payment/src/lib.rs
+++ b/pallets/frequency-tx-payment/src/lib.rs
@@ -372,7 +372,8 @@ where
 		}
 	}
 
-	fn can_withdraw_fee(
+	// simulates fee calculation and withdrawal without applying any changes
+	fn dryrun_withdraw_fee(
 		&self,
 		who: &T::AccountId,
 		call: &<T as frame_system::Config>::RuntimeCall,
@@ -381,16 +382,16 @@ where
 	) -> Result<BalanceOf<T>, TransactionValidityError> {
 		match call.is_sub_type() {
 			Some(Call::pay_with_capacity { call }) =>
-				self.can_withdraw_capacity_fee(who, &vec![*call.clone()], len),
+				self.dryrun_withdraw_capacity_fee(who, &vec![*call.clone()], len),
 
 			Some(Call::pay_with_capacity_batch_all { calls }) =>
-				self.can_withdraw_capacity_fee(who, calls, len),
+				self.dryrun_withdraw_capacity_fee(who, calls, len),
 
-			_ => self.can_withdraw_token_fee(who, call, info, len, self.tip(call)),
+			_ => self.dryrun_withdraw_token_fee(who, call, info, len, self.tip(call)),
 		}
 	}
 
-	fn can_withdraw_capacity_fee(
+	fn dryrun_withdraw_capacity_fee(
 		&self,
 		who: &T::AccountId,
 		calls: &Vec<<T as Config>::RuntimeCall>,
@@ -406,8 +407,8 @@ where
 		T::OnChargeCapacityTransaction::can_withdraw_fee(who, fee.into())?;
 		Ok(fee)
 	}
-	
-	fn can_withdraw_token_fee(
+
+	fn dryrun_withdraw_token_fee(
 		&self,
 		who: &T::AccountId,
 		call: &<T as frame_system::Config>::RuntimeCall,
@@ -533,7 +534,7 @@ where
 		info: &DispatchInfoOf<Self::Call>,
 		len: usize,
 	) -> TransactionValidity {
-		let fee = self.can_withdraw_fee(who, call, info, len)?;
+		let fee = self.dryrun_withdraw_fee(who, call, info, len)?;
 
 		let priority = pallet_transaction_payment::ChargeTransactionPayment::<T>::get_priority(
 			info,

--- a/pallets/frequency-tx-payment/src/lib.rs
+++ b/pallets/frequency-tx-payment/src/lib.rs
@@ -446,7 +446,6 @@ where
 		calls: &Vec<<T as Config>::RuntimeCall>,
 		len: usize,
 	) -> Result<(BalanceOf<T>, InitialPayment<T>), TransactionValidityError> {
-		log::warn!("withdraw_capacity_fee");
 		let mut calls_weight_sum = Weight::zero();
 		for call in calls {
 			let call_weight = T::CapacityCalls::get_stable_weight(call)
@@ -455,7 +454,6 @@ where
 		}
 		let fee = Pallet::<T>::compute_capacity_fee(len as u32, calls_weight_sum);
 
-		log::warn!("withdrawing capacity fee");
 		let fee = T::OnChargeCapacityTransaction::withdraw_fee(key, fee.into())?;
 
 		Ok((fee.into(), InitialPayment::Capacity))

--- a/pallets/frequency-tx-payment/src/lib.rs
+++ b/pallets/frequency-tx-payment/src/lib.rs
@@ -406,6 +406,7 @@ where
 		T::OnChargeCapacityTransaction::can_withdraw_fee(who, fee.into())?;
 		Ok(fee)
 	}
+	
 	fn can_withdraw_token_fee(
 		&self,
 		who: &T::AccountId,

--- a/pallets/frequency-tx-payment/src/tests/pallet_tests.rs
+++ b/pallets/frequency-tx-payment/src/tests/pallet_tests.rs
@@ -880,3 +880,128 @@ fn compute_capacity_fee_returns_fee_when_call_is_capacity_eligible() {
 			assert!(fee_res.inclusion_fee.is_some());
 		});
 }
+
+pub fn assert_can_withdraw_fee_result(
+	account_id: <Test as frame_system::Config>::AccountId,
+	call: &<Test as Config>::RuntimeCall,
+	expected_err: Option<TransactionValidityError>,
+) {
+	let dispatch_info =
+		DispatchInfo { call_weight: Weight::from_parts(5, 0), ..Default::default() };
+
+	let call: &<Test as Config>::RuntimeCall =
+		&RuntimeCall::FrequencyTxPayment(Call::pay_with_capacity { call: Box::new(call.clone()) });
+
+	let can_withdraw_fee = ChargeFrqTransactionPayment::<Test>::from(0u64).can_withdraw_fee(
+		&account_id,
+		call,
+		&dispatch_info,
+		10,
+	);
+
+	match expected_err {
+		None => assert!(can_withdraw_fee.is_ok()),
+		Some(err) => {
+			assert!(can_withdraw_fee.is_err());
+			assert_eq!(err, can_withdraw_fee.err().unwrap())
+		},
+	}
+}
+
+/// can_withdraw_fee, token transactions
+#[test]
+fn can_withdraw_fee_allows_configured_capacity_calls() {
+	let balance_factor = 100_000_000;
+
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_parts(5, 0))
+		.build()
+		.execute_with(|| {
+			let account_id = 1u64;
+			let allowed_call: &<Test as Config>::RuntimeCall =
+				&RuntimeCall::Balances(BalancesCall::transfer_allow_death { dest: 2, value: 100 });
+
+			let forbidden_call: &<Test as Config>::RuntimeCall =
+				&RuntimeCall::Balances(BalancesCall::transfer_all { dest: 2, keep_alive: false });
+
+			assert_can_withdraw_fee_result(account_id, allowed_call, None);
+
+			let expected_err = TransactionValidityError::Invalid(InvalidTransaction::Custom(
+				ChargeFrqTransactionPaymentError::CallIsNotCapacityEligible as u8,
+			));
+			assert_can_withdraw_fee_result(account_id, forbidden_call, Some(expected_err));
+		});
+}
+#[test]
+fn can_withdraw_fee_errors_on_capacity_transaction_without_enough_funds() {
+	let balance_factor = 10;
+
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_parts(5, 0))
+		.build()
+		.execute_with(|| {
+			// An account that has an MSA but has not bet the min balance for key deposit.
+			let account_id = 10u64;
+			let _ = tests::mock::create_msa_account(account_id);
+
+			let call: &<Test as Config>::RuntimeCall =
+				&RuntimeCall::Balances(BalancesCall::transfer_allow_death { dest: 2, value: 100 });
+
+			let expected_err = TransactionValidityError::Invalid(InvalidTransaction::Payment);
+			assert_can_withdraw_fee_result(account_id, call, Some(expected_err));
+		});
+}
+#[test]
+fn can_withdraw_fee_errors_for_capacity_txn_when_invalid_msa() {
+	let balance_factor = 100_000_000;
+
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_parts(5, 0))
+		.build()
+		.execute_with(|| {
+			// An account that has an MSA but has not bet the min balance for key deposit.
+			let account_id_not_associated_with_msa = 10u64;
+			// This allows it not to fail on the requirement of an existential deposit.
+			assert_ok!(Balances::force_set_balance(
+				RawOrigin::Root.into(),
+				account_id_not_associated_with_msa,
+				1u32.into(),
+			));
+
+			let call: &<Test as Config>::RuntimeCall =
+				&RuntimeCall::Balances(BalancesCall::transfer_allow_death { dest: 2, value: 100 });
+
+			let expected_err = TransactionValidityError::Invalid(InvalidTransaction::Custom(
+				ChargeFrqTransactionPaymentError::InvalidMsaKey as u8,
+			));
+			assert_can_withdraw_fee_result(
+				account_id_not_associated_with_msa,
+				call,
+				Some(expected_err),
+			);
+		});
+}
+
+#[test]
+fn can_withdraw_fee_errors_on_token_txn_witout_enough_funds() {
+	let balance_factor = 10;
+
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_parts(100, 0))
+		.build()
+		.execute_with(|| {
+			let charge_tx_payment = ChargeFrqTransactionPayment::<Test>::from(0u64);
+			let who = 1u64;
+			let call: &<Test as Config>::RuntimeCall =
+				&RuntimeCall::Balances(BalancesCall::transfer_allow_death { dest: 2, value: 100 });
+
+			let info = DispatchInfo { call_weight: Weight::from_parts(5, 0), ..Default::default() };
+			let len = 10;
+			let error = charge_tx_payment.can_withdraw_fee(&who, call, &info, len).unwrap_err();
+			assert_eq!(error, TransactionValidityError::Invalid(InvalidTransaction::Payment));
+		});
+}

--- a/pallets/frequency-tx-payment/src/tests/pallet_tests.rs
+++ b/pallets/frequency-tx-payment/src/tests/pallet_tests.rs
@@ -881,7 +881,7 @@ fn compute_capacity_fee_returns_fee_when_call_is_capacity_eligible() {
 		});
 }
 
-pub fn assert_can_withdraw_fee_result(
+pub fn assert_dryrun_withdraw_fee_result(
 	account_id: <Test as frame_system::Config>::AccountId,
 	call: &<Test as Config>::RuntimeCall,
 	expected_err: Option<TransactionValidityError>,
@@ -892,7 +892,7 @@ pub fn assert_can_withdraw_fee_result(
 	let call: &<Test as Config>::RuntimeCall =
 		&RuntimeCall::FrequencyTxPayment(Call::pay_with_capacity { call: Box::new(call.clone()) });
 
-	let can_withdraw_fee = ChargeFrqTransactionPayment::<Test>::from(0u64).can_withdraw_fee(
+	let dryrun_withdraw_fee = ChargeFrqTransactionPayment::<Test>::from(0u64).dryrun_withdraw_fee(
 		&account_id,
 		call,
 		&dispatch_info,
@@ -900,10 +900,10 @@ pub fn assert_can_withdraw_fee_result(
 	);
 
 	match expected_err {
-		None => assert!(can_withdraw_fee.is_ok()),
+		None => assert!(dryrun_withdraw_fee.is_ok()),
 		Some(err) => {
-			assert!(can_withdraw_fee.is_err());
-			assert_eq!(err, can_withdraw_fee.err().unwrap())
+			assert!(dryrun_withdraw_fee.is_err());
+			assert_eq!(err, dryrun_withdraw_fee.err().unwrap())
 		},
 	}
 }
@@ -925,12 +925,12 @@ fn can_withdraw_fee_allows_configured_capacity_calls() {
 			let forbidden_call: &<Test as Config>::RuntimeCall =
 				&RuntimeCall::Balances(BalancesCall::transfer_all { dest: 2, keep_alive: false });
 
-			assert_can_withdraw_fee_result(account_id, allowed_call, None);
+			assert_dryrun_withdraw_fee_result(account_id, allowed_call, None);
 
 			let expected_err = TransactionValidityError::Invalid(InvalidTransaction::Custom(
 				ChargeFrqTransactionPaymentError::CallIsNotCapacityEligible as u8,
 			));
-			assert_can_withdraw_fee_result(account_id, forbidden_call, Some(expected_err));
+			assert_dryrun_withdraw_fee_result(account_id, forbidden_call, Some(expected_err));
 		});
 }
 #[test]
@@ -950,7 +950,7 @@ fn can_withdraw_fee_errors_on_capacity_transaction_without_enough_funds() {
 				&RuntimeCall::Balances(BalancesCall::transfer_allow_death { dest: 2, value: 100 });
 
 			let expected_err = TransactionValidityError::Invalid(InvalidTransaction::Payment);
-			assert_can_withdraw_fee_result(account_id, call, Some(expected_err));
+			assert_dryrun_withdraw_fee_result(account_id, call, Some(expected_err));
 		});
 }
 #[test]
@@ -977,7 +977,7 @@ fn can_withdraw_fee_errors_for_capacity_txn_when_invalid_msa() {
 			let expected_err = TransactionValidityError::Invalid(InvalidTransaction::Custom(
 				ChargeFrqTransactionPaymentError::InvalidMsaKey as u8,
 			));
-			assert_can_withdraw_fee_result(
+			assert_dryrun_withdraw_fee_result(
 				account_id_not_associated_with_msa,
 				call,
 				Some(expected_err),
@@ -1001,7 +1001,7 @@ fn can_withdraw_fee_errors_on_token_txn_witout_enough_funds() {
 
 			let info = DispatchInfo { call_weight: Weight::from_parts(5, 0), ..Default::default() };
 			let len = 10;
-			let error = charge_tx_payment.can_withdraw_fee(&who, call, &info, len).unwrap_err();
+			let error = charge_tx_payment.dryrun_withdraw_fee(&who, call, &info, len).unwrap_err();
 			assert_eq!(error, TransactionValidityError::Invalid(InvalidTransaction::Payment));
 		});
 }

--- a/pallets/msa/src/tests/signed_extension_tests.rs
+++ b/pallets/msa/src/tests/signed_extension_tests.rs
@@ -12,6 +12,7 @@ use sp_runtime::{traits::SignedExtension, transaction_validity::TransactionValid
 // Assert that CheckFreeExtrinsicUse::validate fails with `expected_err_enum`,
 // for the "delete_msa_public_key" call, given extrinsic caller = caller_key,
 // when attempting to delete `public_key_to_delete`
+#[allow(deprecated)]
 fn assert_validate_key_delete_fails(
 	caller_key: &AccountId32,
 	public_key_to_delete: AccountId32,
@@ -34,6 +35,7 @@ fn assert_validate_key_delete_fails(
 	);
 }
 
+#[allow(deprecated)]
 fn assert_revoke_delegation_by_provider_err(
 	expected_err: InvalidTransaction,
 	provider_account: Public,
@@ -55,6 +57,7 @@ fn assert_revoke_delegation_by_provider_err(
 /// Assert that revoking an MSA delegation passes the signed extension CheckFreeExtrinsicUse
 /// validation when a valid delegation exists.
 #[test]
+#[allow(deprecated)]
 fn signed_extension_revoke_delegation_by_delegator_success() {
 	new_test_ext().execute_with(|| {
 		let (provider_msa_id, delegator_account) = create_provider_msa_and_delegator();
@@ -75,6 +78,7 @@ fn signed_extension_revoke_delegation_by_delegator_success() {
 /// Assert that revoking an MSA delegation fails the signed extension CheckFreeExtrinsicUse
 /// validation when no valid delegation exists.
 #[test]
+#[allow(deprecated)]
 fn signed_extension_fails_when_revoke_delegation_by_delegator_called_twice() {
 	new_test_ext().execute_with(|| {
 		let (provider_msa_id, delegator_account) = create_provider_msa_and_delegator();
@@ -110,6 +114,7 @@ fn signed_extension_fails_when_revoke_delegation_by_delegator_called_twice() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn signed_extension_revoke_delegation_by_provider_success() {
 	new_test_ext().execute_with(|| {
 		let (delegator_msa_id, provider_account) = create_delegator_msa_and_provider();
@@ -130,6 +135,7 @@ fn signed_extension_revoke_delegation_by_provider_success() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn signed_extension_revoke_delegation_by_provider_fails_when_no_delegator_msa() {
 	new_test_ext().execute_with(|| {
 		let (_, provider_pair) = create_account();
@@ -142,6 +148,7 @@ fn signed_extension_revoke_delegation_by_provider_fails_when_no_delegator_msa() 
 }
 
 #[test]
+#[allow(deprecated)]
 fn signed_extension_revoke_delegation_by_provider_fails_when_no_provider_msa() {
 	new_test_ext().execute_with(|| {
 		let (provider_pair, _) = sr25519::Pair::generate();
@@ -155,6 +162,7 @@ fn signed_extension_revoke_delegation_by_provider_fails_when_no_provider_msa() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn signed_extension_revoke_delegation_by_provider_fails_when_no_delegation() {
 	new_test_ext().execute_with(|| {
 		let (_, provider_pair) = create_account();
@@ -169,6 +177,7 @@ fn signed_extension_revoke_delegation_by_provider_fails_when_no_delegation() {
 /// Assert that a call that is not one of the matches passes the signed extension
 /// CheckFreeExtrinsicUse validation.
 #[test]
+#[allow(deprecated)]
 fn signed_extension_validation_valid_for_other_extrinsics() {
 	let random_call_should_pass: &<Test as frame_system::Config>::RuntimeCall =
 		&RuntimeCall::Msa(MsaCall::create {});
@@ -185,6 +194,7 @@ fn signed_extension_validation_valid_for_other_extrinsics() {
 
 // Assert that check nonce validation does not create a token account for delete_msa_public_key call.
 #[test]
+#[allow(deprecated)]
 fn signed_ext_check_nonce_delete_msa_public_key() {
 	new_test_ext().execute_with(|| {
 		// Generate a key pair for MSA account
@@ -227,6 +237,7 @@ fn signed_ext_check_nonce_delete_msa_public_key() {
 
 // Assert that check nonce validation does not create a token account for revoke_delegation_by_delegator call.
 #[test]
+#[allow(deprecated)]
 fn signed_ext_check_nonce_revoke_delegation_by_delegator() {
 	new_test_ext().execute_with(|| {
 		let (provider_msa_id, _) = create_provider_msa_and_delegator();
@@ -267,6 +278,7 @@ fn signed_ext_check_nonce_revoke_delegation_by_delegator() {
 
 // Assert that check nonce validation does create a token account for a paying call.
 #[test]
+#[allow(deprecated)]
 fn signed_ext_check_nonce_creates_token_account_if_paying() {
 	new_test_ext().execute_with(|| {
 		//  Test that a  "pays" extrinsic creates a token account
@@ -330,6 +342,7 @@ fn signed_ext_check_nonce_increases_nonce_for_an_existing_account_for_free_trans
 }
 
 #[test]
+#[allow(deprecated)]
 fn signed_extension_validation_delete_msa_public_key_success() {
 	new_test_ext().execute_with(|| {
 		let (msa_id, original_key_pair) = create_account();
@@ -405,6 +418,7 @@ fn signed_extension_validate_fails_when_delete_msa_public_key_called_twice() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn signed_extension_validate_fails_when_delete_msa_public_key_called_on_only_key() {
 	new_test_ext().execute_with(|| {
 		let (_, original_pair) = create_account();
@@ -419,6 +433,7 @@ fn signed_extension_validate_fails_when_delete_msa_public_key_called_on_only_key
 }
 
 #[test]
+#[allow(deprecated)]
 fn signed_extension_validate_fails_when_delete_msa_public_key_called_by_non_owner() {
 	new_test_ext().execute_with(|| {
 		let (_, original_pair) = create_account();

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -108,7 +108,9 @@ start-paseo-collator-bob)
 
 start-frequency-instant)
   printf "\nBuilding Frequency without relay. Running with instant sealing ...\n"
-  cargo build --features frequency-no-relay,force-debug
+  # Uncomment/swap below if you want to see debug logs in the Frequency node
+  # cargo build --features frequency-no-relay,force-debug
+  cargo build --features frequency-no-relay
 
   parachain_dir=$base_dir/parachain/${para_id}
   mkdir -p $parachain_dir;


### PR DESCRIPTION
# Goal
Fixes the double-charge problem and undoes some of the hacks used to make some e2e tests pass.

Followed the model of ChargeTransactionPayment and created a `can_withdraw_fee` function in the Nontransferable trait. Then this is used by `validate` and `withdraw_fee` is only used in `pre_dispatch`.

Following the guidance/direction from Parity, we do not perform the validation steps twice so  `withdraw_fee` doesn't call `can_withdraw_fee`.

This also required adding a `replenishable_balance` to the Nontransferable trait, which isn't  what I'd prefer but the trait generics required it, otherwise it was a mismatch of Balance types.