### PR TITLE
CI Base Image: Update Versions

### DIFF
--- a/.github/workflows/publish-dev-ci-base-image.yml
+++ b/.github/workflows/publish-dev-ci-base-image.yml
@@ -11,6 +11,12 @@ on:
     paths-ignore:
       - "README.md"
       - "LICENSE"
+  pull_request:
+    branches:
+      - ci/ci-base-image
+    paths-ignore:
+      - "README.md"
+      - "LICENSE"
 env:
   RUST_VERSION: 1.84.1
   IMAGE_VERSION: 1.4.0
@@ -42,6 +48,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
+        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -59,7 +66,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ github.event_name == 'push' }}
           file: ci-base-image.dockerfile
           tags: |
             ${{steps.repo_slug.outputs.result}}/${{env.IMAGE_NAME}}:latest

--- a/.github/workflows/publish-dev-ci-base-image.yml
+++ b/.github/workflows/publish-dev-ci-base-image.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       IMAGE_NAME: ci-base-image
       BRANCH_NAME: ${{github.ref_name}}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read

--- a/.github/workflows/publish-dev-ci-base-image.yml
+++ b/.github/workflows/publish-dev-ci-base-image.yml
@@ -67,3 +67,4 @@ jobs:
           build-args: |
             IMAGE_VERSION=${{env.IMAGE_VERSION}}
             RUST_VERSION=${{env.RUST_VERSION}}
+            NIGHTLY_VERSION=${{env.NIGHTLY_VERSION}}

--- a/.github/workflows/publish-dev-ci-base-image.yml
+++ b/.github/workflows/publish-dev-ci-base-image.yml
@@ -54,7 +54,7 @@ jobs:
           script: return `ghcr.io/${context.repo.owner.toLowerCase()}/${context.repo.repo.toLowerCase()}`
 
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/.github/workflows/publish-dev-ci-base-image.yml
+++ b/.github/workflows/publish-dev-ci-base-image.yml
@@ -12,8 +12,10 @@ on:
       - "README.md"
       - "LICENSE"
 env:
-  RUST_VERSION: 1.76.0
-  IMAGE_VERSION: 1.3.1
+  RUST_VERSION: 1.84.1
+  IMAGE_VERSION: 1.4.0
+  # 1.86.0
+  NIGHTLY_VERSION: nightly-2025-04-03
 
 jobs:
   publish-ci-base-image:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A branch specifically for building the CI Docker image and publishing it to the 
 - Go to [.github/workflows/publish-dev-ci-base-image.yml](.github/workflows/publish-dev-ci-base-image.yml)
   - Update `RUST_VERSION` env var
   - Bump `IMAGE_VERSION` env var
+  - Bump `NIGHTLY_VERSION` env var
 - Go to [./ci-base-image.dockerfile](./ci-base-image.dockerfile)
   - Update the `toolchain` references
 - Push

--- a/ci-base-image.dockerfile
+++ b/ci-base-image.dockerfile
@@ -23,8 +23,10 @@ RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/home/runner/.cargo/bin:/root/.cargo/bin:${PATH}"
 ENV RUSTUP_HOME="/root/.cargo"
 ENV CARGO_HOME="/root/.cargo"
-RUN rustup toolchain install nightly-2024-03-01
-RUN rustup target add x86_64-unknown-linux-gnu --toolchain nightly-2024-03-01
-RUN rustup target add wasm32-unknown-unknown --toolchain nightly-2024-03-01
+RUN rustup toolchain install $NIGHTLY_VERSION
+RUN rustup target add x86_64-unknown-linux-gnu --toolchain $NIGHTLY_VERSION
+RUN rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY_VERSION
+RUN rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY_VERSION
+RUN rustup component add rust-src --toolchain $NIGHTLY_VERSION
 
 RUN git config --system --add safe.directory /__w/frequency/frequency

--- a/ci-base-image.dockerfile
+++ b/ci-base-image.dockerfile
@@ -1,7 +1,7 @@
 # NOTE: If you make changes in this file, be sure to update IMAGE_VERSION in merge-pr.yml
 # ci-base-image is published IF and ONLY IF changes are detected in this dockerfile.
 
-FROM --platform=linux/amd64 ubuntu:22.04
+FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 LABEL maintainer="Frequency"
 LABEL description="Frequency CI Base Image"

--- a/ci-base-image.dockerfile
+++ b/ci-base-image.dockerfile
@@ -8,7 +8,7 @@ LABEL description="Frequency CI Base Image"
 # Image version is set by the CI pipeline in merge-pr.yml
 ARG IMAGE_VERSION
 LABEL version="${IMAGE_VERSION}"
-LABEL org.opencontainers.image.description "Frequency CI Base Image"
+LABEL org.opencontainers.image.description="Frequency CI Base Image"
 ARG RUST_VERSION
 LABEL rust.version="${RUST_VERSION}"
 ARG NIGHTLY_VERSION
@@ -25,9 +25,9 @@ RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/home/runner/.cargo/bin:/root/.cargo/bin:${PATH}"
 ENV RUSTUP_HOME="/root/.cargo"
 ENV CARGO_HOME="/root/.cargo"
-RUN rustup toolchain install $NIGHTLY_VERSION
-RUN rustup target add x86_64-unknown-linux-gnu --toolchain $NIGHTLY_VERSION
-RUN rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY_VERSION
-RUN rustup component add rust-src --toolchain $NIGHTLY_VERSION
+RUN rustup toolchain install "${NIGHTLY_VERSION}"
+RUN rustup target add x86_64-unknown-linux-gnu --toolchain "${NIGHTLY_VERSION}"
+RUN rustup target add wasm32-unknown-unknown --toolchain "${NIGHTLY_VERSION}"
+RUN rustup component add rust-src --toolchain "${NIGHTLY_VERSION}"
 
 RUN git config --system --add safe.directory /__w/frequency/frequency

--- a/ci-base-image.dockerfile
+++ b/ci-base-image.dockerfile
@@ -11,6 +11,8 @@ LABEL version="${IMAGE_VERSION}"
 LABEL org.opencontainers.image.description "Frequency CI Base Image"
 ARG RUST_VERSION
 LABEL rust.version="${RUST_VERSION}"
+ARG NIGHTLY_VERSION
+LABEL rust.nightly-version="${NIGHTLY_VERSION}"
 
 WORKDIR /ci
 RUN apt-get update && \

--- a/ci-base-image.dockerfile
+++ b/ci-base-image.dockerfile
@@ -26,7 +26,6 @@ ENV CARGO_HOME="/root/.cargo"
 RUN rustup toolchain install $NIGHTLY_VERSION
 RUN rustup target add x86_64-unknown-linux-gnu --toolchain $NIGHTLY_VERSION
 RUN rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY_VERSION
-RUN rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY_VERSION
 RUN rustup component add rust-src --toolchain $NIGHTLY_VERSION
 
 RUN git config --system --add safe.directory /__w/frequency/frequency


### PR DESCRIPTION
# Goal
The goal of this PR is to update various versions in Frequency build process:

- Use Ubuntu 24.04 in the ci image
- Switch to Rust Version 1.84.1 (used in Polkadot stable2503)
- Switch to Rust nightly version: `nightly-2025-04-03` (This is used for linting, checking, and formatting)
- Update the Docker action `docker/build-push-action`
- Adds CI to PRs to `ci/ci-base-image` to check the build