### PR TITLE
feat(bridging): configure pallet-assets to use MultiLocation

### DIFF
--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -19,6 +19,8 @@ pub fn wasm_binary_unwrap() -> &'static [u8] {
 
 #[cfg(feature = "frequency-bridging")]
 mod xcm_config;
+use xcm_config::ForeignAssetsAssetId;
+
 #[cfg(feature = "frequency-bridging")]
 mod xcm_queue;
 
@@ -375,10 +377,6 @@ pub type BlockId = generic::BlockId<Block>;
 
 /// Block type as expected by this runtime.
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-
-// ---------- Foreign Assets Types (enabled with `frequency-bridging`) ----------
-#[cfg(feature = "frequency-bridging")]
-pub type AssetId = u32;
 
 #[cfg(feature = "frequency-bridging")]
 pub type AssetBalance = Balance;
@@ -1360,8 +1358,8 @@ impl pallet_handles::Config for Runtime {
 impl pallet_assets::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Balance = Balance;
-	type AssetId = AssetId;
-	type AssetIdParameter = AssetId;
+	type AssetId = ForeignAssetsAssetId;
+	type AssetIdParameter = ForeignAssetsAssetId;
 	type Currency = Balances;
 
 	// This is to allow any other remote location to create foreign assets. Used in tests, not

--- a/runtime/frequency/src/xcm_config.rs
+++ b/runtime/frequency/src/xcm_config.rs
@@ -39,6 +39,8 @@ use pallet_xcm::XcmPassthrough;
 
 use polkadot_runtime_common::impls::ToAuthor;
 
+pub type ForeignAssetsAssetId = Location;
+
 parameter_types! {
 	// One XCM operation is 1_000_000_000 weight - almost certainly a conservative estimate.
 	// XCM instruction weight cost

--- a/runtime/frequency/src/xcm_queue.rs
+++ b/runtime/frequency/src/xcm_queue.rs
@@ -1,8 +1,8 @@
 // use crate::{MessageQueue, ParachainSystem, RuntimeBlockWeights, RuntimeCall, RuntimeEvent};
 // use crate::{ParachainSystem, RuntimeBlockWeights, RuntimeCall, RuntimeEvent, AccountId, RuntimeOrigin, Runtime};
 use crate::{
-	AccountId, MessageQueue, ParachainSystem, Runtime, RuntimeBlockWeights, RuntimeEvent,
-	RuntimeOrigin, XcmpQueue,
+	AccountId, MessageQueue, ParachainSystem, Runtime, RuntimeBlockWeights, RuntimeCall,
+	RuntimeEvent, RuntimeOrigin, XcmpQueue,
 };
 // TODO: To fix lint these were removed. Determine if the following imports are necessary:
 //       RuntimeCall


### PR DESCRIPTION
Set the `AssetId` type to `MultiLocation` in the Assets pallet
to enable receiving DOT into the Frequency chain.

Closes #2369 