### PR TITLE
feat(bridging): update ForeignAssets integration and clean up imports

### DIFF
--- a/runtime/frequency/src/xcm_queue.rs
+++ b/runtime/frequency/src/xcm_queue.rs
@@ -4,8 +4,7 @@ use crate::{
 	AccountId, MessageQueue, ParachainSystem, Runtime, RuntimeBlockWeights, RuntimeCall,
 	RuntimeEvent, RuntimeOrigin, XcmpQueue,
 };
-// TODO: To fix lint these were removed. Determine if the following imports are necessary:
-//       RuntimeCall
+
 use frame_support::{
 	parameter_types,
 	traits::{ConstU32, TransformOrigin},


### PR DESCRIPTION
# Goal
The goal of this PR is to update Frequency to allow receiving of DOT using `pallet-assets` as `foreignAssets`.

Closes #2371

# Discussion

- Add the `ForeignAssetsAdapter` type, which is used by `AssetTransactors` to determine how to withdraw and deposit an asset.

# Checklist
- [ ] Updated Pallet Readme?
- [ ] Updated js/api-augment for Custom RPC APIs?
- [ ] Design doc(s) updated?
- [ ] Unit Tests added?
- [ ] e2e Tests added?
- [ ] Benchmarks added?
- [ ] Spec version incremented?
