### PR TITLE
fix(xcm): enable proper handling of XCMP messages

### DIFF
--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -24,6 +24,10 @@ use xcm_config::ForeignAssetsAssetId;
 #[cfg(feature = "frequency-bridging")]
 mod xcm_queue;
 
+#[cfg(feature = "frequency-bridging")]
+pub mod xcm_commons;
+use xcm_commons::{RelayOrigin, ReservedDmpWeight, ReservedXcmpWeight};
+
 use alloc::borrow::Cow;
 use common_runtime::constants::currency::UNITS;
 #[cfg(any(
@@ -1164,11 +1168,37 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type OnSystemEvent = ();
 	type SelfParaId = parachain_info::Pallet<Runtime>;
+
+	#[cfg(feature = "frequency-bridging")]
+	type DmpQueue = frame_support::traits::EnqueueWithOrigin<MessageQueue, RelayOrigin>;
+
+	#[cfg(not(feature = "frequency-bridging"))]
 	type DmpQueue = frame_support::traits::EnqueueWithOrigin<(), sp_core::ConstU8<0>>;
+
+	#[cfg(not(feature = "frequency-bridging"))]
 	type ReservedDmpWeight = ();
+
+	#[cfg(feature = "frequency-bridging")]
+	type ReservedDmpWeight = ReservedDmpWeight;
+
+	#[cfg(not(feature = "frequency-bridging"))]
 	type OutboundXcmpMessageSource = ();
+
+	#[cfg(feature = "frequency-bridging")]
+	type OutboundXcmpMessageSource = XcmpQueue;
+
+	#[cfg(not(feature = "frequency-bridging"))]
 	type XcmpMessageHandler = ();
+
+	#[cfg(feature = "frequency-bridging")]
+	type XcmpMessageHandler = XcmpQueue;
+
+	#[cfg(not(feature = "frequency-bridging"))]
 	type ReservedXcmpWeight = ();
+
+	#[cfg(feature = "frequency-bridging")]
+	type ReservedXcmpWeight = ReservedXcmpWeight;
+
 	type CheckAssociatedRelayNumber = RelayNumberMonotonicallyIncreases;
 	type WeightInfo = ();
 	type ConsensusHook = ConsensusHook;
@@ -1467,17 +1497,21 @@ construct_runtime!(
 		FrequencyTxPayment: pallet_frequency_tx_payment::{Pallet, Call, Event<T>} = 65,
 		Handles: pallet_handles::{Pallet, Call, Storage, Event<T>} = 66,
 		Passkey: pallet_passkey::{Pallet, Call, Storage, Event<T>, ValidateUnsigned} = 67,
-		#[cfg(feature = "frequency-bridging")]
-		ForeignAssets: pallet_assets::{Pallet, Call, Storage, Event<T>} = 68,
 
 		#[cfg(feature = "frequency-bridging")]
 		XcmpQueue: cumulus_pallet_xcmp_queue::{Pallet, Call, Storage, Event<T>} = 71,
+
 		#[cfg(feature = "frequency-bridging")]
-		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>} = 72,
+		PolkadotXcm: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin} = 72,
+
 		#[cfg(feature = "frequency-bridging")]
-		PolkadotXcm: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin} = 73,
+		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin} = 73,
+
 		#[cfg(feature = "frequency-bridging")]
-		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin} = 74
+		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>} = 74,
+
+		#[cfg(feature = "frequency-bridging")]
+		ForeignAssets: pallet_assets::{Pallet, Call, Storage, Event<T>} = 76,
 	}
 );
 

--- a/runtime/frequency/src/xcm_commons.rs
+++ b/runtime/frequency/src/xcm_commons.rs
@@ -1,0 +1,61 @@
+use crate::{AccountId, RuntimeOrigin};
+
+use crate::MAXIMUM_BLOCK_WEIGHT;
+use cumulus_primitives_core::AggregateMessageOrigin;
+use frame_support::parameter_types;
+use pallet_xcm::XcmPassthrough;
+use polkadot_parachain_primitives::primitives::Sibling;
+use staging_xcm::latest::{prelude::*, WESTEND_GENESIS_HASH};
+use staging_xcm_builder::{
+	AccountId32Aliases, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
+	SiblingParachainConvertsVia, SignedAccountId32AsNative, SovereignSignedViaLocation,
+};
+
+/// Shared Relay Network
+pub const RELAY_GENESIS: [u8; 32] = WESTEND_GENESIS_HASH;
+
+parameter_types! {
+	pub const ReservedXcmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
+	pub const ReservedDmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
+	pub const RelayOrigin: AggregateMessageOrigin = AggregateMessageOrigin::Parent;
+}
+
+parameter_types! {
+	pub const RelayNetwork: Option<NetworkId> = Some(NetworkId::ByGenesis(RELAY_GENESIS));
+	pub RelayChainOrigin: RuntimeOrigin = cumulus_pallet_xcm::Origin::Relay.into();
+}
+
+/// Type for specifying how a `Location` can be converted into an `AccountId`. This is used
+/// when determining ownership of accounts for asset transacting and when attempting to use XCM
+/// `Transact` in order to determine the dispatch Origin.
+/// Conversions between Multilocation to an accountid
+/// Parachain origin is converted to corresponding sovereign account
+pub type LocationToAccountId = (
+	// The parent (Relay-chain) origin converts to the parent `AccountId`.
+	ParentIsPreset<AccountId>,
+	// Sibling parachain origins convert to AccountId via the `ParaId::into`.
+	SiblingParachainConvertsVia<Sibling, AccountId>,
+	// Straight up local `AccountId32` origins just alias directly to `AccountId`.
+	AccountId32Aliases<RelayNetwork, AccountId>,
+);
+
+/// This is the type we use to convert an (incoming) XCM origin into a local `Origin` instance,
+/// ready for dispatching a transaction with Xcm's `Transact`. There is an `OriginKind` which can
+/// biases the kind of local `Origin` it will become.
+pub type XcmOriginToTransactDispatchOrigin = (
+	// Sovereign account converter; this attempts to derive an `AccountId` from the origin location
+	// using `LocationToAccountId` and then turn that into the usual `Signed` origin. Useful for
+	// foreign chains who want to have a local sovereign account on this chain which they control.
+	SovereignSignedViaLocation<LocationToAccountId, RuntimeOrigin>,
+	// Native converter for Relay-chain (Parent) location; will convert to a `Relay` origin when
+	// recognized.
+	RelayChainAsNative<RelayChainOrigin, RuntimeOrigin>,
+	// Native converter for sibling Parachains; will convert to a `SiblingPara` origin when
+	// recognized.
+	SiblingParachainAsNative<cumulus_pallet_xcm::Origin, RuntimeOrigin>,
+	// Native signed account converter; this just converts an `AccountId32` origin into a normal
+	// `RuntimeOrigin::Signed` origin of the same 32-byte value.
+	SignedAccountId32AsNative<RelayNetwork, RuntimeOrigin>,
+	// Xcm origins can be represented natively under the Xcm pallet's Xcm origin.
+	XcmPassthrough<RuntimeOrigin>,
+);

--- a/runtime/frequency/src/xcm_queue.rs
+++ b/runtime/frequency/src/xcm_queue.rs
@@ -1,8 +1,6 @@
-// use crate::{MessageQueue, ParachainSystem, RuntimeBlockWeights, RuntimeCall, RuntimeEvent};
-// use crate::{ParachainSystem, RuntimeBlockWeights, RuntimeCall, RuntimeEvent, AccountId, RuntimeOrigin, Runtime};
 use crate::{
 	AccountId, MessageQueue, ParachainSystem, Runtime, RuntimeBlockWeights, RuntimeCall,
-	RuntimeEvent, RuntimeOrigin, XcmpQueue,
+	RuntimeEvent, XcmpQueue,
 };
 
 use frame_support::{
@@ -11,18 +9,13 @@ use frame_support::{
 	weights::Weight,
 };
 
-use polkadot_parachain_primitives::primitives::Sibling;
+use crate::xcm_commons::XcmOriginToTransactDispatchOrigin;
 
 use frame_system::EnsureRoot;
 
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 
 use parachains_common::message_queue::{NarrowOriginToSibling, ParaIdToSibling};
-
-use staging_xcm_builder::{
-	AccountId32Aliases, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
-	SiblingParachainConvertsVia, SignedAccountId32AsNative, SovereignSignedViaLocation,
-};
 
 // use xcm_config;
 #[cfg(not(feature = "runtime-benchmarks"))]
@@ -32,10 +25,6 @@ use polkadot_runtime_common::xcm_sender::NoPriceForMessageDelivery;
 
 pub use sp_runtime::Perbill;
 
-use staging_xcm::latest::prelude::*;
-
-use pallet_xcm::XcmPassthrough;
-
 #[cfg(not(feature = "runtime-benchmarks"))]
 use xcm_executor;
 
@@ -43,50 +32,6 @@ parameter_types! {
 	pub MessageQueueServiceWeight: Weight = Perbill::from_percent(35) * RuntimeBlockWeights::get().max_block;
 }
 
-parameter_types! {
-	// update for dev
-	pub const RelayNetwork: Option<NetworkId> = Some(NetworkId::Polkadot);
-	pub RelayChainOrigin: RuntimeOrigin = cumulus_pallet_xcm::Origin::Relay.into();
-}
-
-/// Type for specifying how a `Location` can be converted into an `AccountId`. This is used
-/// when determining ownership of accounts for asset transacting and when attempting to use XCM
-/// `Transact` in order to determine the dispatch Origin.
-/// Conversions between Multilocation to an accountid
-/// Parachain origin is converted to corresponding souverin account
-pub type LocationToAccountId = (
-	// The parent (Relay-chain) origin converts to the parent `AccountId`.
-	ParentIsPreset<AccountId>,
-	// Sibling parachain origins convert to AccountId via the `ParaId::into`.
-	SiblingParachainConvertsVia<Sibling, AccountId>,
-	// Straight up local `AccountId32` origins just alias directly to `AccountId`.
-	AccountId32Aliases<RelayNetwork, AccountId>,
-);
-
-///////////
-
-/// This is the type we use to convert an (incoming) XCM origin into a local `Origin` instance,
-/// ready for dispatching a transaction with Xcm's `Transact`. There is an `OriginKind` which can
-/// biases the kind of local `Origin` it will become.
-pub type XcmOriginToTransactDispatchOrigin = (
-	// Sovereign account converter; this attempts to derive an `AccountId` from the origin location
-	// using `LocationToAccountId` and then turn that into the usual `Signed` origin. Useful for
-	// foreign chains who want to have a local sovereign account on this chain which they control.
-	SovereignSignedViaLocation<LocationToAccountId, RuntimeOrigin>,
-	// Native converter for Relay-chain (Parent) location; will convert to a `Relay` origin when
-	// recognized.
-	RelayChainAsNative<RelayChainOrigin, RuntimeOrigin>,
-	// Native converter for sibling Parachains; will convert to a `SiblingPara` origin when
-	// recognized.
-	SiblingParachainAsNative<cumulus_pallet_xcm::Origin, RuntimeOrigin>,
-	// Native signed account converter; this just converts an `AccountId32` origin into a normal
-	// `RuntimeOrigin::Signed` origin of the same 32-byte value.
-	SignedAccountId32AsNative<RelayNetwork, RuntimeOrigin>,
-	// Xcm origins can be represented natively under the Xcm pallet's Xcm origin.
-	XcmPassthrough<RuntimeOrigin>,
-);
-
-//////////////////////////
 impl cumulus_pallet_xcmp_queue::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type ChannelInfo = ParachainSystem;


### PR DESCRIPTION
XCMP messages were not reaching the destination sibling
chain due to missing configuration of the `ParachainSystem`
message queues.