### PR TITLE
feat(bridging): add support for Frequency Westend 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ specs-frequency-paseo-local-release:
 	./scripts/generate_specs.sh 2000 frequency-paseo-local release
 
 specs-frequency-westend-local-release:
-	./scripts/generate_specs.sh 2313 frequency-westend-local release
+	./scripts/generate_specs.sh 2000 frequency-westend-local release
 
 specs-frequency-westend-release:
 	./scripts/generate_specs.sh 2313 frequency-westend release

--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,16 @@ all: build
 clean:
 	cargo clean
 
-.PHONY: start start-bridging start-bridging-westend start-frequency start-frequency-docker start-manual start-interval start-interval-short start-with-offchain start-frequency-with-offchain start-manual-with-offchain start-interval-with-offchain
+.PHONY: start start-bridging start-bridging-westend start-bridging-westend-local start-frequency start-frequency-docker start-manual start-interval start-interval-short start-with-offchain start-frequency-with-offchain start-manual-with-offchain start-interval-with-offchain
 start:
 	./scripts/init.sh start-frequency-instant
 
-start-bridging:
-	./scripts/init.sh start-frequency-instant-bridging
+start-bridging-westend-local:
+	./scripts/init.sh start-bridging-westend-local
 
 start-bridging-westend:
-	./scripts/init.sh start-frequency-westend-bridging
+	./scripts/init.sh start-bridging-westend
+	# TODO: Add testnet support
 
 start-paseo-relay:
 	./scripts/init.sh start-paseo-relay-chain
@@ -115,6 +116,12 @@ specs-frequency-paseo-local-debug:
 
 specs-frequency-paseo-local-release:
 	./scripts/generate_specs.sh 2000 frequency-paseo-local release
+
+specs-frequency-westend-local-release:
+	./scripts/generate_specs.sh 2313 frequency-westend-local release
+
+specs-frequency-westend-release:
+	./scripts/generate_specs.sh 2313 frequency-westend release
 
 .PHONY: format
 format:
@@ -250,10 +257,10 @@ docs:
 docker-prune:
 	./scripts/prune_all.sh
 
-.PHONY: check check-no-relay check-local check-testnet check-mainnet check-bridging
+.PHONY: check check-no-relay check-local check-testnet check-westend check-mainnet check-bridging
 # Add a target to run all checks to check that all existing features work with the addition of 'frequency-bridging'
 # which is an add-on feature and not mutually exclusive with the other features.
-check-all: check check-no-relay check-local check-testnet check-mainnet check-bridging
+check-all: check check-no-relay check-local check-testnet check-westend check-mainnet check-bridging
 
 check:
 	SKIP_WASM_BUILD= cargo check --features runtime-benchmarks,frequency-lint-check
@@ -267,6 +274,9 @@ check-local:
 check-testnet:
 	SKIP_WASM_BUILD= cargo check --features frequency-testnet
 
+check-westend:
+	SKIP_WASM_BUILD= cargo check --features frequency-westend
+
 check-mainnet:
 	SKIP_WASM_BUILD= cargo check --features frequency
 
@@ -274,15 +284,19 @@ check-bridging:
 	SKIP_WASM_BUILD= cargo check --features frequency,frequency-bridging
 	SKIP_WASM_BUILD= cargo check --features frequency-testnet,frequency-bridging
 	SKIP_WASM_BUILD= cargo check --features frequency-local,frequency-bridging
+	SKIP_WASM_BUILD= cargo check --features frequency-westend,frequency-bridging
+
+check-bridging-westend:
+	SKIP_WASM_BUILD= cargo check --features frequency-westend,frequency-bridging
 
 
 .PHONY: js
 js:
 	./scripts/generate_js_definitions.sh
 
-.PHONY: build build-benchmarks build-no-relay build-local build-testnet build-mainnet build-testnet-release build-mainnet-release build-bridging-mainnet build-bridging-westend build-all
+.PHONY: build build-benchmarks build-no-relay build-local build-testnet build-westend build-mainnet build-testnet-release build-westend-release build-mainnet-release build-bridging-mainnet build-bridging-westend build-bridging-westend-local build-all
 
-build-all: build build-benchmarks build-no-relay build-local build-testnet build-mainnet build-testnet-release build-mainnet-release build-bridging-mainnet build-bridging-westend
+build-all: build build-benchmarks build-no-relay build-local build-testnet build-westend build-mainnet build-testnet-release build-westend-release build-mainnet-release build-bridging-mainnet build-bridging-westend build-bridging-westend-local
 
 build:
 	cargo build --features frequency-no-relay
@@ -299,11 +313,17 @@ build-local:
 build-testnet:
 	cargo build --features frequency-testnet
 
+build-westend:
+	cargo build --features frequency-westend
+
 build-mainnet:
 	cargo build --features frequency
 
 build-testnet-release:
 	cargo build --locked --features frequency-testnet --release
+
+build-westend-release:
+	cargo build --locked --features frequency-westend --release
 
 build-mainnet-release:
 	cargo build --locked --features  frequency --release
@@ -312,6 +332,9 @@ build-bridging-mainnet:
 	cargo build --features frequency,frequency-bridging
 
 build-bridging-westend:
+	cargo build --features frequency-westend,frequency-bridging --release
+
+build-bridging-westend-local:
 	cargo build --features frequency-local,frequency-bridging --release
 
 .PHONY: test e2e-tests e2e-tests-serial e2e-tests-only e2e-tests-load e2e-tests-load-only e2e-tests-testnet-paseo e2e-tests-paseo-local

--- a/common/primitives/src/utils.rs
+++ b/common/primitives/src/utils.rs
@@ -15,8 +15,8 @@ pub const TESTNET_ON_PASEO_GENESIS_HASH: &[u8] = &[
 
 /// Frequency Testnet on Westend Genesis Hash 0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e
 pub const TESTNET_ON_WESTEND_GENESIS_HASH: &[u8] = &[
-	225, 67, 242, 56, 3, 172, 80, 232, 246, 248, 230, 38, 149, 209, 206, 158, 78, 29, 104, 170,
-	54, 193, 205, 44, 253, 21, 52, 2, 19, 243, 66, 62,
+	225, 67, 242, 56, 3, 172, 80, 232, 246, 248, 230, 38, 149, 209, 206, 158, 78, 29, 104, 170, 54,
+	193, 205, 44, 253, 21, 52, 2, 19, 243, 66, 62,
 ];
 
 /// An enum that shows the detected chain type

--- a/common/primitives/src/utils.rs
+++ b/common/primitives/src/utils.rs
@@ -13,6 +13,12 @@ pub const TESTNET_ON_PASEO_GENESIS_HASH: &[u8] = &[
 	253, 192, 241, 148, 171, 214, 240, 213, 206, 24, 56, 224,
 ];
 
+/// Frequency Testnet on Westend Genesis Hash 0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e
+pub const TESTNET_ON_WESTEND_GENESIS_HASH: &[u8] = &[
+	225, 67, 242, 56, 3, 172, 80, 232, 246, 248, 230, 38, 149, 209, 206, 158, 78, 29, 104, 170,
+	54, 193, 205, 44, 253, 21, 52, 2, 19, 243, 66, 62,
+];
+
 /// An enum that shows the detected chain type
 #[derive(Debug, Clone, PartialEq)]
 pub enum DetectedChainType {
@@ -22,6 +28,8 @@ pub enum DetectedChainType {
 	FrequencyMainNet,
 	/// Frequency Paseo Testnet
 	FrequencyPaseoTestNet,
+	/// Frequency Westend Testnet
+	FrequencyWestendTestNet,
 }
 
 /// Finds the chain type by genesis hash
@@ -29,6 +37,7 @@ pub fn get_chain_type_by_genesis_hash(genesis_hash: &[u8]) -> DetectedChainType 
 	match genesis_hash {
 		MAINNET_GENESIS_HASH => DetectedChainType::FrequencyMainNet,
 		TESTNET_ON_PASEO_GENESIS_HASH => DetectedChainType::FrequencyPaseoTestNet,
+		TESTNET_ON_WESTEND_GENESIS_HASH => DetectedChainType::FrequencyWestendTestNet,
 		_ => DetectedChainType::Unknown,
 	}
 }
@@ -296,5 +305,18 @@ mod tests {
 
 		// assert
 		assert_eq!(detected, DetectedChainType::FrequencyPaseoTestNet);
+	}
+
+	#[test]
+	fn get_chain_type_by_genesis_hash_with_westend_genesis_should_get_westend() {
+		// arrange
+		let known_genesis =
+			from_hex("e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e").unwrap();
+
+		// act
+		let detected = get_chain_type_by_genesis_hash(&known_genesis);
+
+		// assert
+		assert_eq!(detected, DetectedChainType::FrequencyWestendTestNet);
 	}
 }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -39,6 +39,10 @@ frequency-testnet = [
   "frequency-service/frequency-testnet",
   "frequency-cli/frequency-testnet",
 ]
+frequency-westend = [
+  "frequency-service/frequency-westend",
+  "frequency-cli/frequency-westend",
+]
 frequency-lint-check = [
   "frequency-service/frequency-lint-check",
   "frequency-cli/frequency-lint-check",

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -93,11 +93,13 @@ frequency = ["frequency-service/frequency"]
 frequency-no-relay = ["frequency-service/frequency-no-relay"]
 frequency-local = ["frequency-service/frequency-local"]
 frequency-testnet = ["frequency-service/frequency-testnet"]
+frequency-westend = ["frequency-service/frequency-westend"]
 frequency-lint-check = [
   "frequency",
   "frequency-no-relay",
   "frequency-local",
   "frequency-testnet",
+  "frequency-westend",
   "frequency-service/frequency-lint-check",
 ]
 

--- a/node/cli/build.rs
+++ b/node/cli/build.rs
@@ -33,28 +33,48 @@ compile_error!("\"Only one main feature can be enabled except for benchmark/lint
 #[cfg(all(
 	not(feature = "frequency-lint-check"),
 	feature = "frequency-no-relay",
-	any(feature = "frequency", feature = "frequency-local", feature = "frequency-testnet", feature = "frequency-westend")
+	any(
+		feature = "frequency",
+		feature = "frequency-local",
+		feature = "frequency-testnet",
+		feature = "frequency-westend"
+	)
 ))]
 compile_error!("\"Only one main feature can be enabled except for benchmark/lint/check with \"frequency-lint-check\"");
 
 #[cfg(all(
 	not(feature = "frequency-lint-check"),
 	feature = "frequency-local",
-	any(feature = "frequency", feature = "frequency-no-relay", feature = "frequency-testnet", feature = "frequency-westend")
+	any(
+		feature = "frequency",
+		feature = "frequency-no-relay",
+		feature = "frequency-testnet",
+		feature = "frequency-westend"
+	)
 ))]
 compile_error!("\"Only one main feature can be enabled except for benchmark/lint/check with \"frequency-lint-check\"");
 
 #[cfg(all(
 	not(feature = "frequency-lint-check"),
 	feature = "frequency-testnet",
-	any(feature = "frequency", feature = "frequency-no-relay", feature = "frequency-local", feature = "frequency-westend")
+	any(
+		feature = "frequency",
+		feature = "frequency-no-relay",
+		feature = "frequency-local",
+		feature = "frequency-westend"
+	)
 ))]
 compile_error!("\"Only one main feature can be enabled except for benchmark/lint/check with \"frequency-lint-check\"");
 
 #[cfg(all(
 	not(feature = "frequency-lint-check"),
 	feature = "frequency-westend",
-	any(feature = "frequency", feature = "frequency-no-relay", feature = "frequency-local", feature = "frequency-testnet")
+	any(
+		feature = "frequency",
+		feature = "frequency-no-relay",
+		feature = "frequency-local",
+		feature = "frequency-testnet"
+	)
 ))]
 compile_error!("\"Only one main feature can be enabled except for benchmark/lint/check with \"frequency-lint-check\"");
 

--- a/node/cli/build.rs
+++ b/node/cli/build.rs
@@ -4,12 +4,14 @@ use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_change
 	feature = "frequency",
 	feature = "frequency-local",
 	feature = "frequency-no-relay",
-	feature = "frequency-testnet"
+	feature = "frequency-testnet",
+	feature = "frequency-westend"
 )))]
 compile_error!(
 	r#"You must enable one of these features:
 - Mainnet: "frequency"
 - Frequency Paseo: "frequency-testnet"
+- Frequency Westend: "frequency-westend"
 - Local: "frequency-local"
 - No Relay: "frequency-no-relay",
 - All: "frequency-lint-check"#
@@ -22,7 +24,8 @@ compile_error!(
 	any(
 		feature = "frequency-no-relay",
 		feature = "frequency-local",
-		feature = "frequency-testnet"
+		feature = "frequency-testnet",
+		feature = "frequency-westend"
 	)
 ))]
 compile_error!("\"Only one main feature can be enabled except for benchmark/lint/check with \"frequency-lint-check\"");
@@ -30,21 +33,28 @@ compile_error!("\"Only one main feature can be enabled except for benchmark/lint
 #[cfg(all(
 	not(feature = "frequency-lint-check"),
 	feature = "frequency-no-relay",
-	any(feature = "frequency", feature = "frequency-local", feature = "frequency-testnet")
+	any(feature = "frequency", feature = "frequency-local", feature = "frequency-testnet", feature = "frequency-westend")
 ))]
 compile_error!("\"Only one main feature can be enabled except for benchmark/lint/check with \"frequency-lint-check\"");
 
 #[cfg(all(
 	not(feature = "frequency-lint-check"),
 	feature = "frequency-local",
-	any(feature = "frequency", feature = "frequency-no-relay", feature = "frequency-testnet")
+	any(feature = "frequency", feature = "frequency-no-relay", feature = "frequency-testnet", feature = "frequency-westend")
 ))]
 compile_error!("\"Only one main feature can be enabled except for benchmark/lint/check with \"frequency-lint-check\"");
 
 #[cfg(all(
 	not(feature = "frequency-lint-check"),
 	feature = "frequency-testnet",
-	any(feature = "frequency", feature = "frequency-no-relay", feature = "frequency-local",)
+	any(feature = "frequency", feature = "frequency-no-relay", feature = "frequency-local", feature = "frequency-westend")
+))]
+compile_error!("\"Only one main feature can be enabled except for benchmark/lint/check with \"frequency-lint-check\"");
+
+#[cfg(all(
+	not(feature = "frequency-lint-check"),
+	feature = "frequency-westend",
+	any(feature = "frequency", feature = "frequency-no-relay", feature = "frequency-local", feature = "frequency-testnet")
 ))]
 compile_error!("\"Only one main feature can be enabled except for benchmark/lint/check with \"frequency-lint-check\"");
 

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -86,7 +86,7 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 			Ok(Box::new(chain_spec::frequency_paseo_local::local_paseo_testnet_config())),
 		#[cfg(feature = "frequency-bridging")]
 		"frequency-westend-local" =>
-			Ok(Box::new(chain_spec::frequency_westend_local::local_westend_testnet_config())),
+			Ok(Box::new(chain_spec::frequency_westend_local::westend_local_config())),
 		#[cfg(feature = "frequency-testnet")]
 		"frequency-testnet" | "frequency-paseo" | "paseo" | "testnet" =>
 			Ok(Box::new(chain_spec::frequency_paseo::load_frequency_paseo_spec())),
@@ -122,7 +122,7 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 					#[cfg(feature = "frequency-bridging")]
 					{
 						return Ok(Box::new(
-							chain_spec::frequency_westend_local::local_westend_testnet_config(),
+							chain_spec::frequency_westend_local::westend_local_config(),
 						));
 					}
 					#[cfg(not(feature = "frequency-bridging"))]
@@ -293,8 +293,6 @@ impl SubstrateCli for RelayChainCli {
 			// TODO: Remove once on a Polkadot-SDK with Paseo
 			#[cfg(feature = "frequency-testnet")]
 			"paseo" => Ok(Box::new(chain_spec::frequency_paseo::load_paseo_spec())),
-			#[cfg(feature = "frequency-westend")]
-			"westend" => Ok(Box::new(chain_spec::frequency_westend::load_westend_spec())),
 			_ => polkadot_cli::Cli::from_iter([RelayChainCli::executable_name()].iter())
 				.load_spec(id),
 		}

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -25,6 +25,7 @@ enum ChainIdentity {
 	FrequencyLocal,
 	FrequencyDev,
 	FrequencyWestendLocal,
+	FrequencyWestend,
 }
 
 trait IdentifyChain {
@@ -43,6 +44,8 @@ impl IdentifyChain for dyn sc_service::ChainSpec {
 			ChainIdentity::FrequencyDev
 		} else if self.id() == "frequency-westend-local" {
 			ChainIdentity::FrequencyWestendLocal
+		} else if self.id() == "frequency-westend" {
+			ChainIdentity::FrequencyWestend
 		} else {
 			panic!("Unknown chain identity")
 		}
@@ -58,6 +61,7 @@ impl PartialEq for ChainIdentity {
 			(ChainIdentity::FrequencyLocal, ChainIdentity::FrequencyLocal) => true,
 			(ChainIdentity::FrequencyDev, ChainIdentity::FrequencyDev) => true,
 			(ChainIdentity::FrequencyWestendLocal, ChainIdentity::FrequencyWestendLocal) => true,
+			(ChainIdentity::FrequencyWestend, ChainIdentity::FrequencyWestend) => true,
 			_ => false,
 		}
 	}
@@ -86,6 +90,9 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 		#[cfg(feature = "frequency-testnet")]
 		"frequency-testnet" | "frequency-paseo" | "paseo" | "testnet" =>
 			Ok(Box::new(chain_spec::frequency_paseo::load_frequency_paseo_spec())),
+		#[cfg(feature = "frequency-westend")]
+		"frequency-westend" | "westend" =>
+			Ok(Box::new(chain_spec::frequency_westend::load_frequency_westend_spec())),
 		path => {
 			if path.is_empty() {
 				if cfg!(feature = "frequency") {
@@ -129,6 +136,15 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 					}
 					#[cfg(not(feature = "frequency-testnet"))]
 					return Err("Frequency Paseo runtime is not available.".into());
+				} else if cfg!(feature = "frequency-westend") {
+					#[cfg(feature = "frequency-westend")]
+					{
+						return Ok(Box::new(
+							chain_spec::frequency_westend::load_frequency_westend_spec(),
+						));
+					}
+					#[cfg(not(feature = "frequency-westend"))]
+					return Err("Frequency Westend runtime is not available.".into());
 				} else {
 					return Err("No chain spec is available.".into());
 				}
@@ -179,6 +195,15 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 				}
 				#[cfg(not(feature = "frequency-no-relay"))]
 				return Err("Frequency Dev (no relay) runtime is not available.".into());
+			} else if ChainIdentity::FrequencyWestend == spec.identify() {
+				#[cfg(feature = "frequency-westend")]
+				{
+					return Ok(Box::new(chain_spec::frequency_westend::ChainSpec::from_json_file(
+						path_buf,
+					)?));
+				}
+				#[cfg(not(feature = "frequency-westend"))]
+				return Err("Frequency Westend runtime is not available.".into());
 			} else {
 				return Err("Unknown chain spec.".into());
 			}
@@ -268,6 +293,8 @@ impl SubstrateCli for RelayChainCli {
 			// TODO: Remove once on a Polkadot-SDK with Paseo
 			#[cfg(feature = "frequency-testnet")]
 			"paseo" => Ok(Box::new(chain_spec::frequency_paseo::load_paseo_spec())),
+			#[cfg(feature = "frequency-westend")]
+			"westend" => Ok(Box::new(chain_spec::frequency_westend::load_westend_spec())),
 			_ => polkadot_cli::Cli::from_iter([RelayChainCli::executable_name()].iter())
 				.load_spec(id),
 		}

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -127,11 +127,13 @@ frequency = ["frequency-runtime"]
 frequency-no-relay = ["frequency-runtime"]
 frequency-local = ["frequency-runtime"]
 frequency-testnet = ["frequency-runtime"]
+frequency-westend = ["frequency-runtime"]
 frequency-lint-check = [
   "frequency",
   "frequency-no-relay",
   "frequency-local",
   "frequency-testnet",
+  "frequency-westend",
 ]
 try-runtime = ["frequency-runtime/try-runtime", "polkadot-service/try-runtime"]
 

--- a/node/service/src/chain_spec.rs
+++ b/node/service/src/chain_spec.rs
@@ -16,6 +16,9 @@ pub mod frequency;
 #[cfg(feature = "frequency-testnet")]
 pub mod frequency_paseo;
 
+#[cfg(feature = "frequency-westend")]
+pub mod frequency_westend;
+
 #[cfg(any(feature = "frequency-local", feature = "frequency-no-relay"))]
 pub mod frequency_paseo_local;
 

--- a/node/service/src/chain_spec/frequency_westend.rs
+++ b/node/service/src/chain_spec/frequency_westend.rs
@@ -25,7 +25,7 @@ pub fn load_frequency_westend_spec() -> ChainSpec {
 			para_id: 2313,
 		},
 	)
-	.with_name("Frequency Westend Testnet")
+	.with_name("Frequency Westend")
 	.with_id("frequency-westend")
 	.with_protocol_id("frequency-westend")
 	.with_properties(properties)

--- a/node/service/src/chain_spec/frequency_westend.rs
+++ b/node/service/src/chain_spec/frequency_westend.rs
@@ -1,0 +1,26 @@
+#![allow(missing_docs)]
+use polkadot_service::chain_spec::Extensions as RelayChainExtensions;
+
+use super::Extensions;
+
+/// Specialized `ChainSpec` for the normal parachain runtime.
+pub type ChainSpec = sc_service::GenericChainSpec<Extensions>;
+
+// Generic chain spec, in case when we don't have the native runtime.
+pub type RelayChainSpec = sc_service::GenericChainSpec<RelayChainExtensions>;
+
+#[allow(clippy::unwrap_used)]
+/// Generates the Frequency Westend chain spec from the raw json
+pub fn load_frequency_westend_spec() -> ChainSpec {
+    ChainSpec::from_json_bytes(
+        &include_bytes!("../../../../resources/frequency-westend.raw.json")[..],
+    )
+    .unwrap()
+}
+
+#[allow(clippy::unwrap_used)]
+/// Generates the Westend Relay chain spec from the json
+pub fn load_westend_spec() -> RelayChainSpec {
+    RelayChainSpec::from_json_bytes(&include_bytes!("../../../../resources/westend.json")[..])
+        .unwrap()
+}

--- a/node/service/src/chain_spec/frequency_westend.rs
+++ b/node/service/src/chain_spec/frequency_westend.rs
@@ -1,7 +1,10 @@
 #![allow(missing_docs)]
+use common_runtime::constants::{FREQUENCY_TESTNET_TOKEN, TOKEN_DECIMALS};
+use frequency_runtime::Ss58Prefix;
 use polkadot_service::chain_spec::Extensions as RelayChainExtensions;
+use sc_service::ChainType;
 
-use super::Extensions;
+use super::{get_properties, Extensions};
 
 /// Specialized `ChainSpec` for the normal parachain runtime.
 pub type ChainSpec = sc_service::GenericChainSpec<Extensions>;
@@ -9,18 +12,24 @@ pub type ChainSpec = sc_service::GenericChainSpec<Extensions>;
 // Generic chain spec, in case when we don't have the native runtime.
 pub type RelayChainSpec = sc_service::GenericChainSpec<RelayChainExtensions>;
 
-#[allow(clippy::unwrap_used)]
-/// Generates the Frequency Westend chain spec from the raw json
+/// Generates the Frequency Westend chain spec
 pub fn load_frequency_westend_spec() -> ChainSpec {
-    ChainSpec::from_json_bytes(
-        &include_bytes!("../../../../resources/frequency-westend.raw.json")[..],
-    )
-    .unwrap()
-}
+	// Give your base currency a unit name and decimal places
+	let properties =
+		get_properties(FREQUENCY_TESTNET_TOKEN, TOKEN_DECIMALS as u32, Ss58Prefix::get().into());
 
-#[allow(clippy::unwrap_used)]
-/// Generates the Westend Relay chain spec from the json
-pub fn load_westend_spec() -> RelayChainSpec {
-    RelayChainSpec::from_json_bytes(&include_bytes!("../../../../resources/westend.json")[..])
-        .unwrap()
+	ChainSpec::builder(
+		frequency_runtime::wasm_binary_unwrap(),
+		Extensions {
+			relay_chain: "westend".into(), // You MUST set this to the correct network!
+			para_id: 2313,
+		},
+	)
+	.with_name("Frequency Westend Testnet")
+	.with_id("frequency-westend")
+	.with_protocol_id("frequency-westend")
+	.with_properties(properties)
+	.with_chain_type(ChainType::Local)
+	.with_genesis_config_preset_name("frequency-westend")
+	.build()
 }

--- a/node/service/src/chain_spec/frequency_westend.rs
+++ b/node/service/src/chain_spec/frequency_westend.rs
@@ -29,7 +29,7 @@ pub fn load_frequency_westend_spec() -> ChainSpec {
 	.with_id("frequency-westend")
 	.with_protocol_id("frequency-westend")
 	.with_properties(properties)
-	.with_chain_type(ChainType::Local)
+	.with_chain_type(ChainType::Live)
 	.with_genesis_config_preset_name("frequency-westend")
 	.build()
 }

--- a/node/service/src/chain_spec/frequency_westend_local.rs
+++ b/node/service/src/chain_spec/frequency_westend_local.rs
@@ -13,7 +13,7 @@ pub type ChainSpec = sc_service::GenericChainSpec<Extensions>;
 pub type RelayChainSpec = sc_service::GenericChainSpec<RelayChainExtensions>;
 
 /// Generates the chain spec for a local testnet
-pub fn local_westend_testnet_config() -> ChainSpec {
+pub fn westend_local_config() -> ChainSpec {
 	// Give your base currency a unit name and decimal places
 	let properties =
 		get_properties(FREQUENCY_TESTNET_TOKEN, TOKEN_DECIMALS as u32, Ss58Prefix::get().into());

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -47,6 +47,7 @@ pallet-treasury = { path = "../../pallets/treasury", default-features = false }
 default = ["std"]
 frequency = []
 frequency-testnet = []
+frequency-westend = []
 frequency-local = []
 frequency-no-relay = []
 runtime-benchmarks = ["pallet-collective/runtime-benchmarks"]

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -22,11 +22,7 @@ pub mod weights;
 #[macro_export]
 macro_rules! prod_or_testnet_or_local {
 	($prod:expr, $test:expr, $local:expr) => {
-		if cfg!(any(
-			feature = "frequency-local",
-			feature = "frequency-no-relay",
-			feature = "frequency-bridging"
-		)) {
+		if cfg!(any(feature = "frequency-local", feature = "frequency-no-relay",)) {
 			$local
 		} else if cfg!(feature = "frequency-testnet") {
 			$test

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -30,6 +30,8 @@ macro_rules! prod_or_testnet_or_local {
 			$local
 		} else if cfg!(feature = "frequency-testnet") {
 			$test
+		} else if cfg!(feature = "frequency-westend") {
+			$test
 		} else {
 			$prod
 		}

--- a/runtime/frequency/Cargo.toml
+++ b/runtime/frequency/Cargo.toml
@@ -279,6 +279,7 @@ try-runtime = [
 ]
 frequency = ["common-runtime/frequency"]
 frequency-testnet = ["common-runtime/frequency-testnet"]
+frequency-westend = ["common-runtime/frequency-westend"]
 frequency-local = ["common-runtime/frequency-local"]
 frequency-no-relay = ["common-runtime/frequency-no-relay"]
 frequency-bridging = ["common-runtime/frequency-bridging"]

--- a/runtime/frequency/build.rs
+++ b/runtime/frequency/build.rs
@@ -27,6 +27,13 @@ fn main() {
 		.build()
 }
 
+#[cfg(all(feature = "std", feature = "metadata-hash", feature = "frequency-westend"))]
+fn main() {
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.enable_metadata_hash(FREQUENCY_TESTNET_TOKEN, TOKEN_DECIMALS)
+		.build()
+}
+
 #[cfg(all(
 	feature = "std",
 	feature = "metadata-hash",

--- a/runtime/frequency/src/genesis/presets.rs
+++ b/runtime/frequency/src/genesis/presets.rs
@@ -132,7 +132,7 @@ pub fn get_preset(id: &sp_genesis_builder::PresetId) -> Option<Vec<u8>> {
 		#[cfg(feature = "frequency-testnet")]
 		"frequency-testnet" => frequency_testnet_genesis_config(),
 		#[cfg(feature = "frequency-westend")]
-		"frequency-testnet" => frequency_westend_genesis_config(),
+		"frequency-westend" => frequency_westend_genesis_config(),
 		#[cfg(any(feature = "frequency", feature = "runtime-benchmarks"))]
 		"frequency" => frequency_genesis_config(),
 		_ => return None,

--- a/runtime/frequency/src/genesis/presets.rs
+++ b/runtime/frequency/src/genesis/presets.rs
@@ -61,6 +61,19 @@ fn frequency_testnet_genesis_config() -> serde_json::Value {
 	runtime.clone()
 }
 
+#[cfg(feature = "frequency-westend")]
+#[allow(clippy::unwrap_used)]
+fn frequency_westend_genesis_config() -> serde_json::Value {
+	let output: serde_json::Value = serde_json::from_slice(
+		include_bytes!("../../../../resources/frequency-westend.json").as_slice(),
+	)
+	.map_err(|e| format!("Invalid JSON blob {:?}", e))
+	.unwrap();
+
+	let runtime = &output["genesis"]["runtime"];
+	runtime.clone()
+}
+
 #[cfg(any(feature = "frequency", feature = "runtime-benchmarks"))]
 #[allow(clippy::unwrap_used)]
 fn frequency_genesis_config() -> serde_json::Value {
@@ -118,6 +131,8 @@ pub fn get_preset(id: &sp_genesis_builder::PresetId) -> Option<Vec<u8>> {
 		"frequency-westend-local" => frequency_local_genesis_config(),
 		#[cfg(feature = "frequency-testnet")]
 		"frequency-testnet" => frequency_testnet_genesis_config(),
+		#[cfg(feature = "frequency-westend")]
+		"frequency-testnet" => frequency_westend_genesis_config(),
 		#[cfg(any(feature = "frequency", feature = "runtime-benchmarks"))]
 		"frequency" => frequency_genesis_config(),
 		_ => return None,

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -19,6 +19,8 @@ pub fn wasm_binary_unwrap() -> &'static [u8] {
 
 #[cfg(feature = "frequency-bridging")]
 mod xcm_config;
+// use pallet_assets::BenchmarkHelper;
+#[cfg(feature = "frequency-bridging")]
 use xcm_config::ForeignAssetsAssetId;
 
 #[cfg(feature = "frequency-bridging")]
@@ -1659,6 +1661,9 @@ sp_api::impl_runtime_apis! {
 
 			#[cfg(feature = "frequency-testnet")]
 			presets.push(sp_genesis_builder::PresetId::from("frequency-testnet"));
+
+			#[cfg(feature = "frequency-westend")]
+			presets.push(sp_genesis_builder::PresetId::from("frequency-westend"));
 
 			#[cfg(feature = "frequency")]
 			presets.push(sp_genesis_builder::PresetId::from("frequency"));

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -28,6 +28,7 @@ mod xcm_queue;
 
 #[cfg(feature = "frequency-bridging")]
 pub mod xcm_commons;
+#[cfg(feature = "frequency-bridging")]
 use xcm_commons::{RelayOrigin, ReservedDmpWeight, ReservedXcmpWeight};
 
 use alloc::borrow::Cow;
@@ -1417,8 +1418,7 @@ impl pallet_assets::Config for Runtime {
 	type RemoveItemsLimit = frame_support::traits::ConstU32<1000>;
 
 	#[cfg(feature = "runtime-benchmarks")]
-	// type BenchmarkHelper = xcm_config::XcmBenchmarkHelper;
-	type BenchmarkHelper = ();
+	type BenchmarkHelper = xcm_config::XcmBenchmarkHelper;
 	type Holder = ();
 }
 

--- a/runtime/frequency/src/xcm_config.rs
+++ b/runtime/frequency/src/xcm_config.rs
@@ -36,6 +36,24 @@ use polkadot_runtime_common::impls::ToAuthor;
 
 pub type ForeignAssetsAssetId = Location;
 
+#[cfg(feature = "frequency-testnet")]
+use hex_literal::hex;
+#[cfg(feature = "frequency-westend")]
+use staging_xcm::opaque::latest::WESTEND_GENESIS_HASH;
+
+#[cfg(feature = "frequency-testnet")]
+pub const PASEO_GENESIS_HASH: [u8; 32] = 
+	hex!["203c6838fc78ea3660a2f298a58d859519c72a5efdc0f194abd6f0d5ce1838e0"];
+
+#[cfg(feature = "frequency-testnet")]
+const RELAY_NETWORK_ID: Option<NetworkId> = Some(NetworkId::ByGenesis(PASEO_GENESIS_HASH));
+#[cfg(feature = "frequency-westend")]
+const RELAY_NETWORK_ID: Option<NetworkId> = Some(NetworkId::ByGenesis(WESTEND_GENESIS_HASH));
+#[cfg(feature = "frequency")]
+const RELAY_NETWORK_ID: Option<NetworkId> = Some(NetworkId::Polkadot);
+#[cfg(any(feature = "frequency-local", feature = "frequency-no-relay", feature = "frequency-lint-check"))]
+const RELAY_NETWORK_ID: Option<NetworkId> = None;
+
 parameter_types! {
 	pub CheckingAccount: AccountId = PolkadotXcm::check_account();
 }
@@ -50,11 +68,8 @@ parameter_types! {
 
 parameter_types! {
 	pub const RelayLocation: Location = Location::parent();
-	// Update the Relay Network
-	pub const RelayNetwork: Option<NetworkId> = Some(NetworkId::Polkadot);
+	pub const RelayNetwork: Option<NetworkId> = RELAY_NETWORK_ID;
 	pub RelayChainOrigin: RuntimeOrigin = cumulus_pallet_xcm::Origin::Relay.into();
-	// For the real deployment, it is recommended to set `RelayNetwork` according to the relay chain
-	// and prepend `UniversalLocation` with `GlobalConsensus(RelayNetwork::get())`.
 	pub UniversalLocation: InteriorLocation = [GlobalConsensus(RelayNetwork::get().unwrap()), Parachain(ParachainInfo::parachain_id().into())].into();
 	pub HereLocation: Location = Location::here();
 }

--- a/runtime/frequency/src/xcm_config.rs
+++ b/runtime/frequency/src/xcm_config.rs
@@ -32,24 +32,6 @@ use polkadot_runtime_common::impls::ToAuthor;
 
 pub type ForeignAssetsAssetId = Location;
 
-#[cfg(feature = "frequency-testnet")]
-use hex_literal::hex;
-#[cfg(feature = "frequency-westend")]
-use staging_xcm::opaque::latest::WESTEND_GENESIS_HASH;
-
-#[cfg(feature = "frequency-testnet")]
-pub const PASEO_GENESIS_HASH: [u8; 32] = 
-	hex!["203c6838fc78ea3660a2f298a58d859519c72a5efdc0f194abd6f0d5ce1838e0"];
-
-#[cfg(feature = "frequency-testnet")]
-const RELAY_NETWORK_ID: Option<NetworkId> = Some(NetworkId::ByGenesis(PASEO_GENESIS_HASH));
-#[cfg(feature = "frequency-westend")]
-const RELAY_NETWORK_ID: Option<NetworkId> = Some(NetworkId::ByGenesis(WESTEND_GENESIS_HASH));
-#[cfg(feature = "frequency")]
-const RELAY_NETWORK_ID: Option<NetworkId> = Some(NetworkId::Polkadot);
-#[cfg(any(feature = "frequency-local", feature = "frequency-no-relay", feature = "frequency-lint-check"))]
-const RELAY_NETWORK_ID: Option<NetworkId> = None;
-
 parameter_types! {
 	pub CheckingAccount: AccountId = PolkadotXcm::check_account();
 }
@@ -241,4 +223,14 @@ impl pallet_xcm::Config for Runtime {
 impl cumulus_pallet_xcm::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
+}
+
+/// Simple conversion of `u32` into an `AssetId` for use in benchmarking.
+#[cfg(feature = "frequency-bridging")]
+pub struct XcmBenchmarkHelper;
+#[cfg(feature = "runtime-benchmarks")]
+impl pallet_assets::BenchmarkHelper<ForeignAssetsAssetId> for XcmBenchmarkHelper {
+	fn create_asset_id_parameter(id: u32) -> ForeignAssetsAssetId {
+		Location::new(1, [Parachain(id)])
+	}
 }

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -174,7 +174,7 @@ start-frequency-instant-bridging)
   ;;
 
 # TODO: This is a work in progress.
-start-frequency-westend-bridging)
+start-bridging-westend-local)
   printf "\nBuilding Frequency for westend-local with Bridging. Running with local relay ...\n"
   cargo build --features frequency-local,frequency-bridging
 
@@ -201,6 +201,32 @@ start-frequency-westend-bridging)
     --rpc-methods=Unsafe \
     $offchain_params \
     --tmp
+  ;;
+
+# TODO: This needs correct launch parameters for Westend testnet
+start-bridging-westend)
+  printf "\nBuilding Frequency for westend-testnet with Bridging. Running with Westend Testnet Relay ...\n"
+  cargo build --release --features frequency-westend,frequency-bridging
+
+  parachain_dir=$base_dir/parachain/${para_id}
+  mkdir -p $parachain_dir;
+
+  if [ "$2" == "purge" ]; then
+    echo "purging parachain..."
+    rm -rf $parachain_dir
+  fi
+
+  # Placeholder - Needs correct arguments for testnet connection
+  echo "TODO: Add correct launch command for Westend testnet connection"
+  # Example structure (likely needs run_collator.sh):
+  # "${Frequency_BINARY_PATH:-./target/release/frequency}" \
+  #   --collator \
+  #   --chain="frequency-westend-testnet" \
+  #   --base-path=$parachain_dir/data \
+  #   --port $((30333)) \
+  #   --rpc-port $((9944)) \
+  #   -- \
+  #   --chain westend
   ;;
 
 start-frequency-interval)


### PR DESCRIPTION
# Goal
The goal of this PR is to add support for Frequency Testnet on Westend.

Closes #2376

# Discussion

- Added feature `frequency-westend`
- Added test for Westend genesis hash
- Implemented `load_frequency_westend_spec` to build the westend chain spec


# Checklist
- [ ] Updated Pallet Readme?
- [ ] Updated js/api-augment for Custom RPC APIs?
- [ ] Design doc(s) updated?
- [ ] Unit Tests added?
- [ ] e2e Tests added?
- [ ] Benchmarks added?
- [ ] Spec version incremented?
