### PR TITLE
feat: implement pallet_msa::withdraw_tokens extrinsic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7862,6 +7862,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "log",
+ "pallet-balances",
  "pallet-collective",
  "pallet-handles",
  "pallet-schemas",

--- a/e2e/scaffolding/extrinsicHelpers.ts
+++ b/e2e/scaffolding/extrinsicHelpers.ts
@@ -913,4 +913,16 @@ export class ExtrinsicHelper {
       ExtrinsicHelper.api.events.passkey.TransactionExecutionSuccess
     );
   }
+
+  public static withdrawTokens(
+    keys: KeyringPair,
+    ownerKeys: KeyringPair,
+    ownerSignature: MultiSignatureType,
+    payload: AddKeyData
+  ) {
+    return new Extrinsic(
+      () => ExtrinsicHelper.api.tx.msa.withdrawTokens(getUnifiedPublicKey(ownerKeys), ownerSignature, payload),
+      keys
+    );
+  }
 }

--- a/e2e/scaffolding/helpers.ts
+++ b/e2e/scaffolding/helpers.ts
@@ -116,7 +116,7 @@ export async function getBlockNumber(): Promise<number> {
 
 let cacheED: null | bigint = null;
 
-export async function getExistentialDeposit(): Promise<bigint> {
+export function getExistentialDeposit(): bigint {
   if (cacheED !== null) return cacheED;
   return (cacheED = ExtrinsicHelper.api.consts.balances.existentialDeposit.toBigInt());
 }

--- a/pallets/msa/Cargo.toml
+++ b/pallets/msa/Cargo.toml
@@ -25,6 +25,7 @@ sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-weights = { workspace = true }
+pallet-balances = { workspace = true }
 # Frequency related dependencies
 common-primitives = { default-features = false, path = "../../common/primitives" }
 serde = { workspace = true, features = ["derive"] }

--- a/pallets/msa/src/types.rs
+++ b/pallets/msa/src/types.rs
@@ -16,7 +16,9 @@ use scale_info::TypeInfo;
 /// Dispatch Empty
 pub const EMPTY_FUNCTION: fn(MessageSourceId) -> DispatchResult = |_| Ok(());
 
-/// A type definition for the payload of adding an MSA key - `pallet_msa::add_public_key_to_msa`
+/// A type definition for the payload for the following operations:
+/// -  Adding an MSA key - `pallet_msa::add_public_key_to_msa`
+/// -  Authorizing a token withdrawal to an address associated with a public key - `pallet_msa::withdraw_tokens`
 #[derive(
 	TypeInfo, RuntimeDebugNoBound, Clone, Decode, DecodeWithMemTracking, Encode, PartialEq, Eq,
 )]
@@ -24,7 +26,7 @@ pub const EMPTY_FUNCTION: fn(MessageSourceId) -> DispatchResult = |_| Ok(());
 pub struct AddKeyData<T: Config> {
 	/// Message Source Account identifier
 	pub msa_id: MessageSourceId,
-	/// The block number at which the signed proof for add_public_key_to_msa expires.
+	/// The block number at which a signed proof of this payload expires.
 	pub expiration: BlockNumberFor<T>,
 	/// The public key to be added.
 	pub new_public_key: T::AccountId,

--- a/pallets/msa/src/weights.rs
+++ b/pallets/msa/src/weights.rs
@@ -45,6 +45,7 @@ pub trait WeightInfo {
 	fn create_provider_via_governance() -> Weight;
 	fn propose_to_be_provider() -> Weight;
 	fn reindex_offchain() -> Weight;
+	fn withdraw_tokens() -> Weight;
 }
 
 /// Weights for `pallet_msa` using the Substrate node and recommended hardware.
@@ -238,6 +239,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Minimum execution time: 4_000_000 picoseconds.
 		Weight::from_parts(8_000_000, 0)
 	}
+	fn withdraw_tokens() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 4_000_000 picoseconds.
+		Weight::from_parts(8_000_000, 0)
+	}
 }
 
 // For backwards compatibility and tests.
@@ -424,6 +432,13 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(4_u64))
 	}
 	fn reindex_offchain() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 4_000_000 picoseconds.
+		Weight::from_parts(8_000_000, 0)
+	}
+	fn withdraw_tokens() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -587,6 +587,8 @@ impl pallet_msa::Config for Runtime {
 		EnsureRoot<AccountId>,
 		pallet_collective::EnsureMembers<AccountId, CouncilCollective, 1>,
 	>;
+	// The Currency type for managing MSA token balances
+	type Currency = Balances;
 }
 
 parameter_types! {


### PR DESCRIPTION
# Goal
The goal of this PR is to implement an initia `withdraw_tokens` extrinsic that allows MSAs holding tokens to authorize their tokens to be withdrawn to a specified account.

Closes #2388 

# Discussion

# Checklist
- [ ] Updated Pallet Readme?
- [ ] Updated js/api-augment for Custom RPC APIs?
- [ ] Design doc(s) updated?
- [ ] Unit Tests added?
- [x] e2e Tests added?
- [ ] Benchmarks added?
- [ ] Spec version incremented?
