### PR TITLE
Fix release issue with gpg missing

### DIFF
--- a/.github/workflows/benchmarks-run.yml
+++ b/.github/workflows/benchmarks-run.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.repository == 'frequency-chain/frequency'
     name: Build Benchmark Binary
     runs-on: ubicloud-standard-16
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     permissions:
       contents: read
     steps:
@@ -117,7 +117,7 @@ jobs:
     name: Post Benchmark Tests
     needs: run-benchmarks
     runs-on: ubicloud-standard-16
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     permissions:
       contents: read
     steps:

--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -16,7 +16,7 @@ jobs:
     name: Check Migrations on Paseo
     continue-on-error: false
     runs-on: ubicloud-standard-8
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -16,7 +16,7 @@ jobs:
   publish-js-api-augment-rc:
     name: Merge - Publish JS API Augment Release Candidate
     runs-on: ubicloud-standard-4
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
   calc-code-coverage:
     name: Merge - Calculate Code Coverage
     runs-on: ubicloud-standard-30
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
     needs: create-release-branch
     name: Run All Benchmarks - Build
     runs-on: ubicloud-standard-16
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     permissions:
       contents: read
     steps:
@@ -154,7 +154,7 @@ jobs:
     needs: run-all-benchmarks-bench
     name: Run All Benchmarks - Test
     runs-on: ubicloud-standard-16
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -233,7 +233,7 @@ jobs:
           - arch: arm64
             runner: ubicloud-standard-16-arm
     runs-on: ${{matrix.runner}}
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     env:
       SIGNING_SUBKEY_FINGERPRINT: B6327D1474C6392032870E8EFA4FD1E73A0FE707
     steps:
@@ -394,7 +394,7 @@ jobs:
     needs: version-code
     name: Build Rust Developer Docs
     runs-on: ubicloud-standard-4
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -427,7 +427,7 @@ jobs:
       RELEASE_FILENAME_PREFIX: frequency-local
       ARCH: amd64
     runs-on: ubuntu-24.04
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     steps:
       - name: Set Env Vars
         run: |
@@ -479,7 +479,7 @@ jobs:
   build-js-schemas:
     name: Build JS Schemas
     runs-on: ubuntu-24.04
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -721,7 +721,7 @@ jobs:
     needs: wait-for-all-builds
     name: Release Built Artifacts
     runs-on: ubuntu-24.04
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     permissions:
       contents: write
     steps:

--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -184,7 +184,7 @@ jobs:
             arch: arm64
             runner: ubicloud-standard-30-arm
     runs-on: ${{matrix.runner}}
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     env:
       NETWORK: mainnet
     steps:
@@ -231,7 +231,7 @@ jobs:
     if: needs.changes.outputs.cargo-lock == 'true'
     name: Check for Vulnerable Crates
     runs-on: ubuntu-24.04
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -247,7 +247,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Verify Rust Code Format
     runs-on: ubuntu-24.04
-    container: ghcr.io/frequency-chain/frequency/ci-base-image-nightly:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image-nightly:1.5.6
     steps:
       - name: Check Out Repository
         uses: actions/checkout@v4
@@ -261,7 +261,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Lint Rust Code
     runs-on: ubicloud-standard-4
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -277,7 +277,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Verify Rust Developer Docs
     runs-on: ubicloud-standard-4
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -290,7 +290,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Verify Rust Packages and Dependencies
     runs-on: ubicloud-standard-4
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -302,7 +302,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Run Rust Tests
     runs-on: ubicloud-standard-8
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -317,7 +317,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Calculate Code Coverage
     runs-on: ubicloud-standard-30
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -430,7 +430,7 @@ jobs:
     needs: build-binaries
     name: Verify JS API Augment
     runs-on: ubuntu-24.04
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -489,7 +489,7 @@ jobs:
   verify-js-schemas:
     name: Verify JS Schemas
     runs-on: ubuntu-24.04
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -656,7 +656,7 @@ jobs:
     needs: build-binaries
     name: Check Metadata and Spec Version
     runs-on: ubuntu-24.04
-    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.5
+    container: ghcr.io/frequency-chain/frequency/ci-base-image:1.5.6
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/verify-pr-commit.yml
+++ b/.github/workflows/verify-pr-commit.yml
@@ -205,8 +205,9 @@ jobs:
       #     key: binaries-${{runner.os}}-${{env.NETWORK}}-${{github.head_ref}}
       - name: Compile Binary for ${{matrix.network}} on ${{matrix.arch}}
         if: steps.cache-binary.outputs.cache-hit != 'true'
+        # The various rust flags here are for faster builds, but are not exactly the same as release builds
         run: |
-          CARGO_INCREMENTAL=0 RUSTFLAGS="-D warnings" cargo build --locked \
+          CARGO_INCREMENTAL=0 RUSTFLAGS="-D warnings -C debuginfo=0 -C opt-level=0 -C codegen-units=265" cargo build --locked \
             ${{ matrix.build-profile == 'release' && '--release' || '' }} \
             --features ${{matrix.spec}}
       - name: Run Sanity Checks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,6 +194,9 @@ large_enum_variant = "allow"
 empty_line_after_outer_attr = "allow"
 enum_variant_names = "allow"
 
+# debug is profile.dev
+# Defaults: https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles
+
 [profile.release]
 panic = "unwind"
 lto = true


### PR DESCRIPTION
# Goal
The goal of this PR is to update the ci image to v1.5.6 (which has gpg installed)

Also does a small verify pr commit tweak that speeds up the build by about 1.5 minutes