### PR TITLE
Boosting: adjust constants

### DIFF
--- a/runtime/common/src/constants.rs
+++ b/runtime/common/src/constants.rs
@@ -380,7 +380,7 @@ impl core::fmt::Debug for MaxItemizedBlobSizeBytes {
 // --- Capacity Pallet ---
 pub type CapacityMinimumStakingAmount = ConstU128<{ currency::EXISTENTIAL_DEPOSIT }>;
 pub type CapacityMinimumTokenBalance = ConstU128<{ currency::DOLLARS }>;
-pub type CapacityMaxUnlockingChunks = ConstU32<4>;
+pub type CapacityMaxUnlockingChunks = ConstU32<40>;
 pub type CapacityMaxEpochLength = ConstU32<{ 2 * DAYS }>; // Two days, assuming 6 second blocks.
 
 #[cfg(not(any(feature = "frequency-local", feature = "frequency-no-relay")))]

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -630,7 +630,7 @@ impl StakingConfigProvider for FreqeuncyStakingConfigProvider {
 				reward_percent_cap: Permill::from_parts(8_000),
 			},
 			StakingType::MaximumCapacity | StakingType::FlexibleBoost =>
-				StakingConfig { reward_percent_cap: Permill::from_parts(5_750) }, // 0.575% or 0.00575 per RewardEra
+				StakingConfig { reward_percent_cap: Permill::from_parts(3_833) }, // 0.3833% or 0.003833 per RewardEra
 		}
 	}
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to

- Increase MaxUnlockingChunks to 40 to accommodate extended unlocks.
- Adjust RewardPercentCap:
   - From: Permill::from_parts(5_750); 0.575%
   - To: Permill::from_parts(3_833); 0.3833%

