### PR TITLE
chore(test): update sent-to-relay

### DIFF
--- a/emulated-test/Cargo.lock
+++ b/emulated-test/Cargo.lock
@@ -1745,8 +1745,6 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "smallvec",
- "sp-api",
  "sp-core",
  "sp-externalities",
  "sp-io",
@@ -1760,23 +1758,23 @@ version = "0.0.0"
 dependencies = [
  "common-primitives",
  "cumulus-pallet-weight-reclaim",
+ "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-core",
  "frame-support",
  "frame-system",
+ "pallet-assets",
  "pallet-balances",
  "pallet-collator-selection",
  "pallet-collective",
  "pallet-democracy",
+ "pallet-message-queue",
  "pallet-multisig",
  "pallet-preimage",
  "pallet-proxy",
  "pallet-scheduler",
  "pallet-session",
- "pallet-sudo",
- "pallet-time-release",
  "pallet-timestamp",
  "pallet-transaction-payment",
- "pallet-treasury 27.0.0",
  "pallet-utility",
  "parity-scale-codec",
  "scale-info",
@@ -2341,16 +2339,6 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
-]
-
-[[package]]
-name = "cumulus-primitives-timestamp"
-version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2503-6#598feddb893f5ad3923a62e41a2f179b6e10c30c"
-dependencies = [
- "cumulus-primitives-core",
- "sp-inherents",
- "sp-timestamp",
 ]
 
 [[package]]
@@ -3575,7 +3563,6 @@ dependencies = [
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-aura",
  "cumulus-primitives-core",
- "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "frame-executive",
  "frame-metadata-hash-extension",
@@ -3583,7 +3570,6 @@ dependencies = [
  "frame-system",
  "frame-system-rpc-runtime-api",
  "hex",
- "hex-literal",
  "log",
  "pallet-assets",
  "pallet-aura",
@@ -3626,9 +3612,7 @@ dependencies = [
  "polkadot-parachain-primitives",
  "polkadot-runtime-common",
  "scale-info",
- "serde",
  "serde_json",
- "smallvec",
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
@@ -6624,7 +6608,6 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
  "pallet-capacity",
  "pallet-msa",
  "pallet-transaction-payment",
@@ -6639,7 +6622,6 @@ dependencies = [
 name = "pallet-frequency-tx-payment-runtime-api"
 version = "0.0.0"
 dependencies = [
- "common-primitives",
  "frame-support",
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6678,7 +6660,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "handles-utils",
- "log",
  "numtoa",
  "parity-scale-codec",
  "scale-info",
@@ -6789,7 +6770,6 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
  "multibase",
  "parity-scale-codec",
  "scale-info",
@@ -6803,7 +6783,6 @@ name = "pallet-messages-runtime-api"
 version = "0.0.0"
 dependencies = [
  "common-primitives",
- "frame-support",
  "sp-api",
 ]
 
@@ -6883,7 +6862,6 @@ name = "pallet-msa-runtime-api"
 version = "0.0.0"
 dependencies = [
  "common-primitives",
- "frame-support",
  "parity-scale-codec",
  "sp-api",
 ]
@@ -7055,12 +7033,10 @@ dependencies = [
  "frame-support",
  "frame-system",
  "lazy_static",
- "log",
  "p256",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
- "serde_json",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -7254,7 +7230,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-weights",
 ]
 
 [[package]]
@@ -7262,9 +7237,7 @@ name = "pallet-schemas-runtime-api"
 version = "0.0.0"
 dependencies = [
  "common-primitives",
- "frame-support",
  "sp-api",
- "sp-runtime",
 ]
 
 [[package]]
@@ -7401,7 +7374,6 @@ name = "pallet-stateful-storage-runtime-api"
 version = "0.0.0"
 dependencies = [
  "common-primitives",
- "frame-support",
  "sp-api",
  "sp-runtime",
 ]
@@ -7428,7 +7400,6 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -7487,7 +7458,6 @@ dependencies = [
 name = "pallet-treasury"
 version = "27.0.0"
 dependencies = [
- "common-primitives",
  "docify",
  "frame-benchmarking",
  "frame-support",
@@ -11733,11 +11703,7 @@ name = "system-runtime-api"
 version = "0.0.0"
 dependencies = [
  "common-primitives",
- "frame-support",
- "frame-system",
- "serde_json",
  "sp-api",
- "sp-runtime",
 ]
 
 [[package]]

--- a/emulated-test/test/frequency-westend/src/lib.rs
+++ b/emulated-test/test/frequency-westend/src/lib.rs
@@ -68,6 +68,13 @@ mod imports {
 			<Balances as Inspect<_>>::balance(who)
 		})
 	}
+
+	pub fn relay_balance_of(who: &AccountIdOf<<Westend as Chain>::Runtime>) -> Balance {
+		Westend::execute_with(|| {
+			type Balances = <Westend as WestendPallet>::Balances;
+			<Balances as Inspect<_>>::balance(who)
+		})
+	}
 }
 
 #[macro_export]

--- a/emulated-test/test/frequency-westend/src/tests/mod.rs
+++ b/emulated-test/test/frequency-westend/src/tests/mod.rs
@@ -10,6 +10,6 @@ mod teleport_xfrqcy_to_assethub_with_dot_fee;
 
 mod teleport_xfrqcy_with_dot_fee_from_assethub;
 
-mod send_xcm_to_relay;
+mod send_xcm_to_relay_with_root;
 
 mod utils;

--- a/emulated-test/test/frequency-westend/src/tests/send_xcm_to_relay_with_root.rs
+++ b/emulated-test/test/frequency-westend/src/tests/send_xcm_to_relay_with_root.rs
@@ -1,0 +1,102 @@
+use crate::{foreign_balance_on, imports::*};
+
+fn frequency_to_relay_send_xcm(t: FrequencyToRelayTest) -> DispatchResult {
+	type RuntimeCall = <FrequencyWestend as Chain>::RuntimeCall;
+	let asset_on_relay: Assets = (Here, 1_000_000_000_000u128).into();
+	let asset_fees: Assets = (Here, 1_000_000_000_000u128 / 2).into();
+
+	let remote_xcm = Xcm::<()>(vec![
+		WithdrawAsset(asset_on_relay.clone()),
+		BuyExecution { fees: asset_fees.get(0).unwrap().clone(), weight_limit: Unlimited },
+		DepositAsset {
+			assets: Wild(All),
+			beneficiary: AccountId32Junction { network: None, id: WestendReceiver::get().into() }
+				.into(),
+		},
+	]);
+
+	let sudo_inner_call: <FrequencyWestend as Chain>::RuntimeCall =
+		RuntimeCall::PolkadotXcm(pallet_xcm::Call::send {
+			dest: bx!(VersionedLocation::V5(Parent.into())),
+			message: bx!(VersionedXcm::V5(remote_xcm)),
+		});
+
+	let _ = <FrequencyWestend as FrequencyWestendPallet>::Sudo::sudo(
+		t.root_origin,
+		bx!(sudo_inner_call),
+	);
+
+	Ok(())
+}
+
+fn assert_xcm_processed_on_relay(_t: FrequencyToRelayTest) {
+	Westend::assert_ump_queue_processed(
+		true,
+		Some(FrequencyWestend::para_id()),
+		Some(Weight::from_parts(311_685_000, 7_186)),
+	);
+}
+
+fn assert_xcm_is_sent_to_relay(_t: FrequencyToRelayTest) {
+	FrequencyWestend::assert_parachain_system_ump_sent();
+}
+
+pub fn fund_sov_frequency_on_westend(amount: Balance) {
+	let freq_location = Westend::child_location_of(FrequencyWestend::para_id());
+	let sov_account = Westend::sovereign_account_id_of(freq_location);
+	Westend::fund_accounts(vec![(sov_account.into(), amount)]);
+}
+
+// =========================================================================
+// ========= Send XCM to Relay ===========
+// =========================================================================
+// This test is used to test the XCM sending functionality from Frequency to Relay.
+// It test that the fee is waived for the XCM if it comes from root.
+// RUST_BACKTRACE=1 RUST_LOG="events,runtime::system=trace,xcm=trace" cargo test tests::send_xcm_to_relay_with_root -- --nocapture
+/// Tests reserve transfer of DOT from Frequency to Relay (Westend) with root.
+/// This test passing checks that the FeeManager is setup to waive the delivery fee for XCMs sent from root.
+#[test]
+fn send_xcm_to_relay_with_root() {
+	let sender = FrequencyWestendSender::get();
+	let receiver = WestendReceiver::get();
+	let amount_to_send: Balance = WESTEND_ED * 1000;
+
+	fund_sov_frequency_on_westend(amount_to_send * 2);
+
+	let assets: Assets = (Parent, amount_to_send).into();
+	let destination = FrequencyWestend::parent_location();
+
+	let freq_location = Westend::child_location_of(FrequencyWestend::para_id());
+	let sov_account = Westend::sovereign_account_id_of(freq_location);
+	assert_eq!(relay_balance_of(&sov_account), 20_000_000_000_000);
+
+	let test_args = TestContext {
+		sender: sender.clone(),
+		receiver: receiver.clone(),
+		args: TestArgs::new_para(
+			destination.clone(),
+			receiver,
+			amount_to_send,
+			assets.clone(),
+			None,
+			0,
+		),
+	};
+
+	let mut test = FrequencyToRelayTest::new(test_args);
+
+	let dot_location = WestendLocation::get();
+
+	test.set_assertion::<FrequencyWestend>(assert_xcm_is_sent_to_relay);
+	test.set_assertion::<Westend>(assert_xcm_processed_on_relay);
+	test.set_dispatchable::<FrequencyWestend>(frequency_to_relay_send_xcm);
+	test.assert();
+
+	// Checks that the treasury account has not been credited since the deliveryfee is waived.
+	let treasury_account_balance = foreign_balance_on!(
+		FrequencyWestend,
+		dot_location.clone(),
+		&FrequencyTreasuryAccount::get()
+	);
+	assert_eq!(treasury_account_balance, 0u128, "Treasury account should NOT have been credited");
+}


### PR DESCRIPTION
Update sent to relay test so that it ensures
the xcm is processed by the relay chain.

This test is intented to test that sending
an xcm with root will sucessfully send.

It also checks that the treasury account is not credited since the fee is waived for root account.chore(test): improve sent-to-relay test coverage

Update the sent-to-relay test to ensure the XCM message is properly processed by the relay chain.

This test verifies that:
- An XCM message sent with `Root` origin executes successfully.
- The treasury account is not credited, as fees are waived for root-origin messages.
