### PR TITLE
Fix E2E Tests Improve

### DIFF
--- a/e2e/msa/msaTokens.test.ts
+++ b/e2e/msa/msaTokens.test.ts
@@ -25,6 +25,7 @@ import {
   signPayload,
 } from '../scaffolding/helpers';
 import { u64 } from '@polkadot/types';
+import autoNonce from '../scaffolding/autoNonce';
 
 let fundingSource: KeyringPair;
 const TRANSFER_AMOUNT = 1n * DOLLARS;
@@ -317,6 +318,8 @@ describe('MSAs Holding Tokens', function () {
       ({ ownerSig } = await generateSignedAuthorizedKeyPayload(msaKeys, newPayload));
       const op2 = ExtrinsicHelper.withdrawTokens(keys, msaKeys, ownerSig, newPayload);
       await assert.doesNotReject(op2.signAndSend(), 'token transfer transaction should have succeeded');
+      // withdrawTokens doesn't change the nonce
+      autoNonce.reset(keys);
       // Destination account should have had balance increased
       const {
         data: { free: endingBalance },

--- a/e2e/scenarios/grantDelegation.test.ts
+++ b/e2e/scenarios/grantDelegation.test.ts
@@ -198,7 +198,8 @@ describe('Delegation Scenario Tests', function () {
       .filter((grant) => grant.revoked_at.toBigInt() === 0n)
       .map((grant) => grant.schema_id.toNumber());
     const expectedSchemaIds = [schemaId.toNumber(), schemaId2.toNumber()];
-    assert.deepStrictEqual(grantedSchemaIds, expectedSchemaIds);
+    // Sort them as order doesn't matter
+    assert.deepStrictEqual(grantedSchemaIds.sort(), expectedSchemaIds.sort());
   });
 
   it('should get all delegations and grants', async function () {


### PR DESCRIPTION
# Goal
The goal of this PR is to make some of the e2e tests less flaky.

# Discussion

-  withdrawTokens doesn't change the nonce, so reset the autononce system for it
- Delegations don't need to be checked for order, just contents