### PR TITLE
chore(misc): clean up linting and unused asset locking configs

### DIFF
--- a/emulated-test/test/frequency-westend/src/lib.rs
+++ b/emulated-test/test/frequency-westend/src/lib.rs
@@ -34,11 +34,13 @@ mod imports {
 		frequency_emulated_chain::{
 			frequency_runtime::{
 				self,
-				xcm::CheckingAccount as FrequencyCheckingAccount,
-				xcm::XcmConfig as FrequencyXcmConfig,
+				xcm::{
+					CheckingAccount as FrequencyCheckingAccount, XcmConfig as FrequencyXcmConfig,
+				},
 				ExistentialDeposit as FrequencyExistentialDeposit,
 			},
-			FrequencyAssetOwner, FrequencyWestendParaPallet as FrequencyWestendPallet, TreasuryAccount as FrequencyTreasuryAccount,
+			FrequencyAssetOwner, FrequencyWestendParaPallet as FrequencyWestendPallet,
+			TreasuryAccount as FrequencyTreasuryAccount,
 		},
 		westend_emulated_chain::{genesis::ED as WESTEND_ED, WestendRelayPallet as WestendPallet},
 		AssetHubWestendPara as AssetHubWestend,

--- a/emulated-test/test/frequency-westend/src/tests/execute_transact_instruction_fails.rs
+++ b/emulated-test/test/frequency-westend/src/tests/execute_transact_instruction_fails.rs
@@ -1,5 +1,7 @@
-use crate::imports::frequency_runtime::{PolkadotXcm, Runtime, RuntimeCall, RuntimeOrigin};
-use crate::imports::*;
+use crate::imports::{
+	frequency_runtime::{PolkadotXcm, Runtime, RuntimeCall, RuntimeOrigin},
+	*,
+};
 use frame_support::assert_err_ignore_postinfo;
 use parity_scale_codec::Encode;
 

--- a/emulated-test/test/frequency-westend/src/tests/mod.rs
+++ b/emulated-test/test/frequency-westend/src/tests/mod.rs
@@ -10,7 +10,7 @@ mod teleport_xfrqcy_to_assethub_with_dot_fee;
 
 mod teleport_xfrqcy_with_dot_fee_from_assethub;
 
-mod send_xcm_to_relay_with_root;
 mod execute_transact_instruction_fails;
+mod send_xcm_to_relay_with_root;
 
 mod utils;

--- a/emulated-test/test/frequency-westend/src/tests/utils.rs
+++ b/emulated-test/test/frequency-westend/src/tests/utils.rs
@@ -96,7 +96,6 @@ pub fn mint_dot_on_frequency_v2(
 	});
 }
 
-
 pub fn mint_xrqcy_on_asset_hub(
 	beneficiary: AccountIdOf<<AssetHubWestend as Chain>::Runtime>,
 	amount_to_mint: Balance,

--- a/pallets/stateful-storage/src/tests/apply_item_actions_tests.rs
+++ b/pallets/stateful-storage/src/tests/apply_item_actions_tests.rs
@@ -675,9 +675,9 @@ fn apply_item_actions_with_signature_v2_having_invalid_schema_id_should_fail() {
 				RuntimeOrigin::signed(caller_1),
 				delegator_key.into(),
 				owner_signature,
-				payload
+				payload,
 			),
-			Error::<Test>::InvalidSchemaId
+			Error::<Test>::InvalidSchemaId,
 		)
 	});
 }

--- a/runtime/frequency/src/xcm/xcm_config.rs
+++ b/runtime/frequency/src/xcm/xcm_config.rs
@@ -6,8 +6,8 @@ use crate::{
 use staging_xcm_builder::{EnsureXcmOrigin, FrameTransactionalProcessor};
 
 use crate::xcm::{
-	AssetTransactors, Barrier, FeeManager, LocalOriginToLocation, LocationToAccountId,
-	MaxAssetsIntoHolding, Trader, TrustedReserves, TrustedTeleporters, UniversalLocation, Weigher,
+	AssetTransactors, Barrier, FeeManager, LocalOriginToLocation, MaxAssetsIntoHolding, Trader,
+	TrustedReserves, TrustedTeleporters, UniversalLocation, Weigher,
 	XcmOriginToTransactDispatchOrigin, XcmRouter,
 };
 
@@ -41,8 +41,6 @@ impl xcm_executor::Config for XcmConfig {
 	type AssetTransactor = AssetTransactors;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
 	type IsReserve = TrustedReserves;
-	// in order to register our asset in asset hub
-	// once the asset is registered we can teleport our native asset to asset hub
 	type IsTeleporter = TrustedTeleporters;
 	type UniversalLocation = UniversalLocation;
 	type Barrier = Barrier;
@@ -71,38 +69,34 @@ impl xcm_executor::Config for XcmConfig {
 
 impl pallet_xcm::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type WeightInfo = pallet_xcm::TestWeightInfo;
+
 	type SendXcmOrigin = EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;
 	type XcmRouter = XcmRouter;
+
 	type ExecuteXcmOrigin = EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;
-	// update to Nothing and create extrinsic
 	type XcmExecuteFilter = Everything;
-	// ^ Disable dispatchable execute on the XCM pallet.
-	// Needs to be `Everything` for local testing.
 	type XcmExecutor = XcmExecutor<XcmConfig>;
-	// update to only allow to teleport native
 	type XcmTeleportFilter = Everything;
-	// Lets only allow reserve transfers of DOT
 	type XcmReserveTransferFilter = Everything;
 	type Weigher = Weigher;
 	type UniversalLocation = UniversalLocation;
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
 
 	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
 	// ^ Override for AdvertisedXcmVersion default
 	type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
+
+	type AdminOrigin = EnsureRoot<AccountId>;
+
 	type Currency = Balances;
 	type CurrencyMatcher = ();
 	type TrustedLockers = ();
-	// I do not thingk we need this
-	type SovereignAccountOf = LocationToAccountId;
-	/// Not sure what this is for?
-	type MaxLockers = ConstU32<8>;
-	type WeightInfo = pallet_xcm::TestWeightInfo;
-	type AdminOrigin = EnsureRoot<AccountId>;
+	type MaxLockers = ConstU32<0>;
 	type MaxRemoteLockConsumers = ConstU32<0>;
 	type RemoteLockConsumerIdentifier = ();
-	// Aliasing is disabled: xcm_executor::Config::Aliasers is set to `Nothing`.
+	type SovereignAccountOf = ();
 	type AuthorizedAliasConsideration = Disabled;
 }
 


### PR DESCRIPTION
Clean up linting issues and disable unused configurations:
- SouvereSovereignAccountOf
- MaxLockers

These configurations are part of the asset locking feature
in pallet-xcm, which is not used in our runtime.