### PR TITLE
Implement types and pallet storage for Intents and IntentGroups

### DIFF
--- a/common/primitives/src/schema.rs
+++ b/common/primitives/src/schema.rs
@@ -11,6 +11,12 @@ use sp_runtime::RuntimeDebug;
 #[cfg(feature = "std")]
 use utils::*;
 
+/// DelegationGrpup Id is the unique identifier for a DelegationGroup
+pub type IntentGroupId = u16;
+
+/// Intent Id is the unique identifier for an Intent
+pub type IntentId = u16;
+
 /// Schema Id is the unique identifier for a Schema
 pub type SchemaId = u16;
 
@@ -95,6 +101,36 @@ pub enum SchemaSetting {
 #[derive(Clone, Copy, PartialEq, Eq, Default, RuntimeDebug)]
 pub struct SchemaSettings(pub BitFlags<SchemaSetting>);
 
+/// TODO: temporary alias until Schemas are updated in an upcoming PR
+pub type IntentSetting = SchemaSetting;
+
+/// TODO: temporary alias until Schemas are updated in an upcoming PR
+pub type IntentSettings = SchemaSettings;
+
+/// RPC response structure for an IntentGroup
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Clone, Encode, Decode, PartialEq, Debug, TypeInfo, Eq)]
+pub struct IntentGroupResponse {
+	/// The unique identifier for this IntentGroup
+	pub intent_group_id: u16,
+	/// The list of currently supported IntentIds for this IntentGroup
+	pub intent_ids: Option<Vec<IntentId>>,
+}
+
+/// RPC response structure for an Intent
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Clone, Encode, Decode, PartialEq, Debug, TypeInfo, Eq)]
+pub struct IntentResponse {
+	/// The unique identifier for this Intent
+	pub intent_id: IntentId,
+	/// The payload location
+	pub payload_location: PayloadLocation,
+	/// settings for the Intent
+	pub settings: Vec<IntentSetting>,
+	/// The list of currently-supported SchemaIds for this Intent
+	pub schema_ids: Option<Vec<SchemaId>>,
+}
+
 /// RPC Response form for a Schema
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Clone, Encode, Decode, PartialEq, Debug, TypeInfo, Eq)]
@@ -135,9 +171,9 @@ pub trait SchemaProvider<SchemaId> {
 	fn get_schema_info_by_id(schema_id: SchemaId) -> Option<SchemaInfoResponse>;
 }
 
-/// This allows other Pallets to check validity of schema ids.
+/// This allows other Pallets to check the validity of schema ids.
 pub trait SchemaValidator<SchemaId> {
-	/// Checks that a collection of SchemaIds are all valid
+	/// Checks that a collection of SchemaIds is all valid
 	fn are_all_schema_ids_valid(schema_ids: &[SchemaId]) -> bool;
 
 	/// Set the schema counter for testing purposes.

--- a/runtime/common/src/constants.rs
+++ b/runtime/common/src/constants.rs
@@ -99,6 +99,10 @@ parameter_types! {
 	/// The maximum length of a schema model (in bytes)
 	pub const SchemasMaxBytesBoundedVecLimit :u32 = 65_500;
 }
+/// The maximum number of Intent registrations
+pub type IntentsMaxRegistrations = ConstU16<65_000>;
+/// The maximum number of Intents that can belong to a single IntentGroup
+pub type IntentGroupMaxIntents = ConstU32<10>;
 /// The maximum number of schema registrations
 pub type SchemasMaxRegistrations = ConstU16<65_000>;
 /// The minimum schema model size (in bytes)

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -653,6 +653,10 @@ impl pallet_capacity::Config for Runtime {
 impl pallet_schemas::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = pallet_schemas::weights::SubstrateWeight<Runtime>;
+	// The maximum number of intents that can be registered
+	type MaxIntentRegistrations = IntentsMaxRegistrations;
+	// The maximum number of intents that can belong to a single IntentGroup
+	type MaxIntentsPerIntentGroup = IntentGroupMaxIntents;
 	// The mininum size (in bytes) for a schema model
 	type MinSchemaModelSizeBytes = SchemasMinModelSizeBytes;
 	// The maximum number of schemas that can be registered


### PR DESCRIPTION
# Goal
The goal of this PR is to implement *only* the *types* and *pallet storage* for the following new on-chain entities:
* Intents
* IntentGroups

Incremental work for #2550 (TODO: replace with actual issue link once the epic issues are filled out)

# Checklist
- [ ] Updated Pallet Readme?
- [ ] Updated js/api-augment for Custom RPC APIs?
- [ ] Design doc(s) updated?
- [ ] Unit Tests added?
- [ ] e2e Tests added?
- [ ] Benchmarks added?
- [ ] Spec version incremented?
