### PR TITLE
feat: types, storage, and runtime RPCs for entity Names (Intent, IntentGroup)

### DIFF
--- a/common/primitives/src/schema.rs
+++ b/common/primitives/src/schema.rs
@@ -162,6 +162,44 @@ pub struct SchemaInfoResponse {
 	pub settings: Vec<SchemaSetting>,
 }
 
+#[derive(
+	Copy,
+	Clone,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	PartialEq,
+	Debug,
+	TypeInfo,
+	Eq,
+	MaxEncodedLen,
+	Serialize,
+	Deserialize,
+)]
+/// Enum type for the different types of entities that a FullyQualifiedName can represent
+pub enum MappedEntityIdentifier {
+	/// An Intent
+	Intent(IntentId),
+	/// An IntentGroup
+	IntentGroup(IntentGroupId),
+}
+
+impl Default for MappedEntityIdentifier {
+	fn default() -> Self {
+		Self::Intent(Default::default())
+	}
+}
+
+/// RPC response form for a name resolution lookup
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Clone, Encode, Decode, PartialEq, Debug, TypeInfo, Eq)]
+pub struct NameLookupResponse {
+	/// The name for this entity
+	pub name: Vec<u8>,
+	/// The resolved entity
+	pub entity_id: MappedEntityIdentifier,
+}
+
 /// This allows other pallets to resolve Schema information. With generic SchemaId
 pub trait SchemaProvider<SchemaId> {
 	/// Gets the Schema details associated with this `SchemaId` if any

--- a/e2e/scaffolding/helpers.ts
+++ b/e2e/scaffolding/helpers.ts
@@ -314,7 +314,7 @@ export function getEthereumKeyPairFromUnifiedAddress(unifiedAddress: string): Ke
 function canDrainAccount(info: FrameSystemAccountInfo): boolean {
   return (
     !info.isEmpty &&
-    info.data.free.toNumber() > 1_500_000 && // ~Cost to do the transfer
+    info.data.free.toNumber() > 1_900_000 && // ~Cost to do the transfer
     info.data.reserved.toNumber() < 1 &&
     info.data.frozen.toNumber() < 1
   );

--- a/pallets/schemas/src/runtime-api/src/lib.rs
+++ b/pallets/schemas/src/runtime-api/src/lib.rs
@@ -35,7 +35,7 @@ sp_api::decl_runtime_apis! {
 		fn get_by_schema_id(schema_id: SchemaId) -> Option<SchemaResponse>;
 		/// Fetch the schema versions by name
 		fn get_schema_versions_by_name(schema_name: Vec<u8>) -> Option<Vec<SchemaVersionResponse>>;
-		
+
 		#[api_version(3)]
 		/// Fetch registered entity identifiers by name
 		fn get_registered_entities_by_name(name: Vec<u8>) -> Option<Vec<NameLookupResponse>>;

--- a/pallets/schemas/src/runtime-api/src/lib.rs
+++ b/pallets/schemas/src/runtime-api/src/lib.rs
@@ -35,6 +35,7 @@ sp_api::decl_runtime_apis! {
 		fn get_by_schema_id(schema_id: SchemaId) -> Option<SchemaResponse>;
 		/// Fetch the schema versions by name
 		fn get_schema_versions_by_name(schema_name: Vec<u8>) -> Option<Vec<SchemaVersionResponse>>;
+		
 		#[api_version(3)]
 		/// Fetch registered entity identifiers by name
 		fn get_registered_entities_by_name(name: Vec<u8>) -> Option<Vec<NameLookupResponse>>;

--- a/pallets/schemas/src/runtime-api/src/lib.rs
+++ b/pallets/schemas/src/runtime-api/src/lib.rs
@@ -35,5 +35,8 @@ sp_api::decl_runtime_apis! {
 		fn get_by_schema_id(schema_id: SchemaId) -> Option<SchemaResponse>;
 		/// Fetch the schema versions by name
 		fn get_schema_versions_by_name(schema_name: Vec<u8>) -> Option<Vec<SchemaVersionResponse>>;
+		#[api_version(3)]
+		/// Fetch registered entity identifiers by name
+		fn get_registered_entities_by_name(name: Vec<u8>) -> Option<Vec<NameLookupResponse>>;
 	}
 }

--- a/pallets/schemas/src/tests/other_tests.rs
+++ b/pallets/schemas/src/tests/other_tests.rs
@@ -701,8 +701,8 @@ fn get_intent_or_group_ids_for_namespace_should_return_all_descriptors() {
 		// assert
 		// assert!(entity_ids.is_some());
 
-		let mut inner = entity_ids.clone().unwrap();
-		inner.sort_by(|a, b| a.name.cmp(&b.name));
+		// let mut inner = entity_ids.clone().unwrap();
+		// inner.sort_by(|a, b| a.name.cmp(&b.name));
 		// assert_eq!(
 		// 	entity_ids,
 		// 	Some(vec![
@@ -742,7 +742,7 @@ fn get_intent_or_group_ids_for_fully_qualified_name_should_return_single_descrip
 		// assert
 		// assert!(entity_ids.is_some());
 
-		let mut inner = entity_ids.clone().unwrap();
+		// let mut inner = entity_ids.clone().unwrap();
 		// assert_eq!(
 		// 	entity_ids,
 		// 	Some(vec![

--- a/pallets/schemas/src/types.rs
+++ b/pallets/schemas/src/types.rs
@@ -1,8 +1,8 @@
 //! Types for the Schema Pallet
 use crate::{Config, Error};
 use common_primitives::schema::{
-	IntentId, IntentSetting, IntentSettings, ModelType, PayloadLocation, SchemaId, SchemaSetting,
-	SchemaSettings, SchemaVersion, SchemaVersionResponse,
+	IntentId, IntentSetting, IntentSettings, MappedEntityIdentifier, ModelType, NameLookupResponse,
+	PayloadLocation, SchemaId, SchemaSetting, SchemaSettings, SchemaVersion, SchemaVersionResponse,
 };
 use core::fmt::Debug;
 use frame_support::{ensure, pallet_prelude::ConstU32, traits::StorageVersion, BoundedVec};
@@ -104,6 +104,10 @@ pub struct SchemaName {
 	/// name or descriptor of this schema
 	pub descriptor: SchemaDescriptor,
 }
+
+/// A structure defining a fully qualified name of an entity
+// TODO: type alias for now, until we finish converting the Schemas and deprecate the old methods
+pub type FullyQualifiedName = SchemaName;
 
 #[derive(Clone, Encode, Decode, PartialEq, Debug, TypeInfo, Eq, MaxEncodedLen, Default)]
 /// A structure defining name of a schema
@@ -219,5 +223,17 @@ impl SchemaVersionId {
 				schema_version: (index + 1) as SchemaVersion,
 			})
 			.collect()
+	}
+}
+
+/// trait to create a response from a name and entity identifier
+pub trait ConvertToResponse<I, R> {
+	/// method to convert to response
+	fn convert_to_response(&self, name: &I) -> R;
+}
+
+impl ConvertToResponse<SchemaName, NameLookupResponse> for MappedEntityIdentifier {
+	fn convert_to_response(&self, name: &SchemaName) -> NameLookupResponse {
+		NameLookupResponse { name: name.get_combined_name(), entity_id: *self }
 	}
 }

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -119,7 +119,7 @@ pub use pallet_time_release::types::{ScheduleName, SchedulerProviderTrait};
 // Polkadot Imports
 use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
 
-use common_primitives::capacity::UnclaimedRewardInfo;
+use common_primitives::{capacity::UnclaimedRewardInfo, schema::NameLookupResponse};
 use common_runtime::weights::rocksdb_weights::constants::RocksDbWeight;
 pub use common_runtime::{
 	constants::MaxSchemaGrants,
@@ -1670,6 +1670,7 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
+	#[api_version(3)]
 	impl pallet_schemas_runtime_api::SchemasRuntimeApi<Block> for Runtime {
 		fn get_by_schema_id(schema_id: SchemaId) -> Option<SchemaResponse> {
 			Schemas::get_schema_by_id(schema_id)
@@ -1677,6 +1678,10 @@ sp_api::impl_runtime_apis! {
 
 		fn get_schema_versions_by_name(schema_name: Vec<u8>) -> Option<Vec<SchemaVersionResponse>> {
 			Schemas::get_schema_versions(schema_name)
+		}
+
+		fn get_registered_entities_by_name(name: Vec<u8>) -> Option<Vec<NameLookupResponse>> {
+			Schemas::get_intent_or_group_ids_by_name(name)
 		}
 	}
 


### PR DESCRIPTION
# Description
This PR implments type, storage, and runtime RPCs for mapping fully qualified names of the form `<protocol>.<descriptor>` to Intents or IntentGroups.

Additional tests & support will be the subject of an upcoming PR; this is only merging to a feature branch.

Closes #2562 

# Discussion

- <!-- List discussion items -->

# Checklist
- [ ] Updated Pallet Readme?
- [ ] Updated js/api-augment for Custom RPC APIs?
- [ ] Design doc(s) updated?
- [ ] Unit Tests added?
- [ ] e2e Tests added?
- [ ] Benchmarks added?
- [ ] Spec version incremented?
