### PR TITLE
bugfix: fixed capacity estimation RPC

### DIFF
--- a/pallets/frequency-tx-payment/src/lib.rs
+++ b/pallets/frequency-tx-payment/src/lib.rs
@@ -265,14 +265,14 @@ impl<T: Config> Pallet<T> {
 	/// Compute the capacity fee details for a transaction.
 	/// # Arguments
 	/// * `runtime_call` - The runtime call to be dispatched.
-	/// * `weight` - The weight of the transaction.
+	/// * `overhead_weight` - The overhead weight asociated with capacity transactions.
 	/// * `len` - The length of the transaction.
 	///
 	/// # Returns
 	/// `FeeDetails` - The fee details for the transaction.
 	pub fn compute_capacity_fee_details(
 		runtime_call: &<T as Config>::RuntimeCall,
-		dispatch_weight: &Weight,
+		overhead_weight: &Weight,
 		len: u32,
 	) -> FeeDetails<BalanceOf<T>> {
 		let calls = T::CapacityCalls::get_inner_calls(runtime_call)
@@ -286,7 +286,7 @@ impl<T: Config> Pallet<T> {
 
 		let mut fees = FeeDetails { inclusion_fee: None, tip: Zero::zero() };
 		if !calls_weight_sum.is_zero() {
-			if let Some(weight) = calls_weight_sum.checked_add(dispatch_weight) {
+			if let Some(weight) = calls_weight_sum.checked_add(overhead_weight) {
 				let weight_fee = Self::weight_to_fee(weight);
 				let len_fee = Self::length_to_fee(len);
 				let base_fee = Self::weight_to_fee(CAPACITY_EXTRINSIC_BASE_WEIGHT);

--- a/runtime/frequency/src/lib.rs
+++ b/runtime/frequency/src/lib.rs
@@ -640,7 +640,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("frequency"),
 	impl_name: Cow::Borrowed("frequency"),
 	authoring_version: 1,
-	spec_version: 178,
+	spec_version: 179,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -654,7 +654,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("frequency-testnet"),
 	impl_name: Cow::Borrowed("frequency"),
 	authoring_version: 1,
-	spec_version: 178,
+	spec_version: 179,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -1950,16 +1950,16 @@ sp_api::impl_runtime_apis! {
 
 			// if the call is wrapped in a batch, we need to get the weight of the outer call
 			// and use that to compute the fee with the inner call's stable weight(s)
-			let dispatch_weight = match &uxt.function {
-				RuntimeCall::FrequencyTxPayment(pallet_frequency_tx_payment::Call::pay_with_capacity { .. }) |
-				RuntimeCall::FrequencyTxPayment(pallet_frequency_tx_payment::Call::pay_with_capacity_batch_all { .. }) => {
-					<<Block as BlockT>::Extrinsic as GetDispatchInfo>::get_dispatch_info(&uxt).call_weight
-				},
+			let capacity_overhead_weight = match &uxt.function {
+				RuntimeCall::FrequencyTxPayment(pallet_frequency_tx_payment::Call::pay_with_capacity { .. }) =>
+					<() as pallet_frequency_tx_payment::WeightInfo>::pay_with_capacity(),
+				RuntimeCall::FrequencyTxPayment(pallet_frequency_tx_payment::Call::pay_with_capacity_batch_all { calls, .. }) =>
+					<() as pallet_frequency_tx_payment::WeightInfo>::pay_with_capacity_batch_all(calls.len() as u32),
 				_ => {
 					Weight::zero()
 				}
 			};
-			FrequencyTxPayment::compute_capacity_fee_details(&uxt.function, &dispatch_weight, len)
+			FrequencyTxPayment::compute_capacity_fee_details(&uxt.function, &capacity_overhead_weight, len)
 		}
 	}
 


### PR DESCRIPTION
# Goal
The goal of this PR is to fix the bug in capacity estimation RPC.

Closes #2579

# Discussion
- The issue was using the weight from extrinsic which includes the inner calls instead of getting the bare capacity weights directly.

# Checklist
- [X] Spec version incremented?

# Verification
As shown Calculated and deducted capacity values are really close.

<img width="1565" height="494" alt="Screenshot 2025-09-18 at 4 28 54 PM" src="https://github.com/user-attachments/assets/1fcb074a-5462-45b1-ae70-39a6d5dc7ebd" />
<img width="1443" height="492" alt="Screenshot 2025-09-18 at 4 29 11 PM" src="https://github.com/user-attachments/assets/692f79a7-91a9-41a5-866e-c5ee13154fc1" />

