### PR TITLE
[Chore] remove deprecation from `create_provider` 

### DIFF
--- a/pallets/msa/src/lib.rs
+++ b/pallets/msa/src/lib.rs
@@ -697,10 +697,6 @@ pub mod pallet {
 		/// * [`Error::DuplicateProviderRegistryEntry`] - a ProviderRegistryEntry associated with the given MSA id already exists.
 		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::create_provider())]
-		#[allow(deprecated)]
-		#[deprecated(
-			note = "please use `create_provider_via_governance_v2`, `propose_to_be_provider_v2`which supports additional provider metadata"
-		)]
 		pub fn create_provider(origin: OriginFor<T>, provider_name: Vec<u8>) -> DispatchResult {
 			let provider_key = ensure_signed(origin)?;
 			let provider_msa_id = Self::ensure_valid_msa_key(&provider_key)?;


### PR DESCRIPTION
# Goal
The goal of this PR is to retain and remove `deprecated` marking from `create_provider` since it is actively used in paseo/local testing. Also notify repository of changes expected to be implemented.

Closes #2610 
# Discussion

* [Discussion](https://github.com/frequency-chain/frequency/pull/2549#discussion_r2361092004) with ND/Joe.

# Checklist
- [ ] Updated Pallet Readme?
- [ ] Updated js/api-augment for Custom RPC APIs?
- [ ] Design doc(s) updated?
- [ ] Unit Tests added?
- [ ] e2e Tests added?
- [ ] Benchmarks added?
- [ ] Spec version incremented?
